### PR TITLE
Release v1.1.0

### DIFF
--- a/.github/workflows/publish_images.yml
+++ b/.github/workflows/publish_images.yml
@@ -14,7 +14,7 @@ jobs:
       packages: write
     steps:
       - name: Checkout Code
-        uses: actions/checkout@v3.3.0
+        uses: actions/checkout@v3.4.0
 
       - name: Revert CPU limit
         run: |

--- a/README.md
+++ b/README.md
@@ -49,7 +49,7 @@ Start the container with
 ## Notes
 
 - Based on current Alpine version 3:17
-- Final image size is ~175 MB
+- Final image size is ~190 MB
 - All `make` calles use the option `-j $(( $(nproc) -1 ))` to leave one CPU for normal operation
 - Compiling `snapserver`
   - A deprecated option needs to be removed on the `airplay-stream.cpp`

--- a/README.md
+++ b/README.md
@@ -50,10 +50,9 @@ Start the container with
 
 - Based on current Alpine version 3:17
 - Final image size is ~190 MB
-- All `make` calles use the option `-j $(( $(nproc) -1 ))` to leave one CPU for normal operation
+- All `(c)make` calles use the option `-j $(( $(nproc) -1 ))` to leave one CPU for normal operation
 - Compiling `snapserver`
   - A deprecated option needs to be removed on the `airplay-stream.cpp`
-  - The compiler flag `HAS_EXPAT=1` needs to be set for Airplay metadata
 - `s6-overlay` is used as `init` system (same as the [shairport-sync docker image](https://github.com/mikebrady/shairport-sync/tree/master/docker)). This is necessary, because *shairport-sync* needs a companion application called [NQPTP](https://github.com/mikebrady/nqptp) which needs to be started from `root` to run as deamon.
   - The `ENTRYPOINT ["/init"]` is set within the [docker-alpine-s6 base image](https://github.com/crazy-max/docker-alpine-s6) already
   - `s6-rc` with configured dependencies is used to start all services. `snapserver` should start as last

--- a/README.md
+++ b/README.md
@@ -61,4 +61,4 @@ Start the container with
 - [Snapweb](https://github.com/badaix/snapweb) is inclued in the image and can be accessed on `http://<snapserver host>:1780`
 - `hop`  is included for debugging purposes
 - `shairport-sync-metadata-reader` is inclued for debuging purposes
-- I tried to provide multi-arch images as well, however, cross-compiling/building on Github with `QEMU` and `buildx` took hours and was canceled a few times automatically. I tried with a Debian based images as well, but no avail. The `debian.dockerfile` should provide a usable image with only minor necesary changes to the `s6` files. Debian images are ~307 MB.
+- I tried to provide multi-arch images as well, however, cross-compiling/building on Github with `QEMU` and `buildx` took hours and was canceled a few times automatically. I tried with a Debian based images as well, but no avail. The `debian.dockerfile` should provide a usable image with only minor necesary changes to the `s6` files. Debian images are ~334 MB.

--- a/alpine.dockerfile
+++ b/alpine.dockerfile
@@ -39,7 +39,7 @@ RUN apk add --no-cache \
     xmltoman \
     xxd
 # SNAPWEB
-RUN npm install -g typescript@latest
+RUN npm install -g typescript@4.9.5
 
 ###### LIBRESPOT START ######
 FROM base AS librespot

--- a/alpine.dockerfile
+++ b/alpine.dockerfile
@@ -1,7 +1,6 @@
 FROM docker.io/alpine:3.17 as base
 RUN apk add --no-cache \
     # LIBRESPOT
-    cargo \
     git \
     musl-dev\
     pkgconfig \
@@ -41,6 +40,10 @@ RUN apk add --no-cache \
 
 ###### LIBRESPOT START ######
 FROM base AS librespot
+# Install cargo/rust from 'edge' as it is v1.68 which uses the new "sparse" protocol which speeds up the cargo index update massively
+RUN apk add --no-cache cargo --repository=https://dl-cdn.alpinelinux.org/alpine/edge/community
+# https://blog.rust-lang.org/inside-rust/2023/01/30/cargo-sparse-protocol.html
+ENV CARGO_REGISTRIES_CRATES_IO_PROTOCOL="sparse"
 RUN git clone https://github.com/librespot-org/librespot \
    && cd librespot \
    && git checkout a211ff94c6c9d11b78964aad91b2a7db1d17d04f

--- a/alpine.dockerfile
+++ b/alpine.dockerfile
@@ -56,7 +56,7 @@ FROM base AS snapcast
 ### SNAPSERVER ###
 RUN git clone https://github.com/badaix/snapcast.git /snapcast \
     && cd snapcast \
-    && git checkout 54a3d86200a52a36ab5cf1d699eee572539db52d \
+    && git checkout 5968f96e11d4abf21e8b50cfe9ae306cdec29d57 \
     && sed -i 's/\-\-use-stderr //' "./server/streamreader/airplay_stream.cpp" \
     && sed -i 's/LOG(INFO, LOG_TAG) << "Waiting for metadata/LOG(DEBUG, LOG_TAG) << "Waiting for metadata/' "./server/streamreader/airplay_stream.cpp"
 WORKDIR /snapcast
@@ -80,7 +80,7 @@ FROM base AS shairport
 ### NQPTP ###
 RUN git clone https://github.com/mikebrady/nqptp
 WORKDIR /nqptp
-RUN git checkout 845219c74cd0e35cd344da9f0a37c6e7d3e576f2 \
+RUN git checkout 576273509779f31b9e8b4fa32087dea7105fa8c7 \
     && autoreconf -i \
     && ./configure \
     && make -j $(( $(nproc) -1 ))
@@ -110,7 +110,7 @@ WORKDIR /
 ### SPS ###
 RUN git clone https://github.com/mikebrady/shairport-sync.git /shairport\
     && cd /shairport \
-    && git checkout aa1d578bc2b188dbcbb0d07f1b84dbf2dd683314
+    && git checkout a1c9387ca81bedebb986e237403db0cd57ae45dc
 WORKDIR /shairport/build
 RUN autoreconf -i ../ \
     && ../configure --sysconfdir=/etc \

--- a/alpine.dockerfile
+++ b/alpine.dockerfile
@@ -45,7 +45,7 @@ RUN npm install -g typescript@latest
 FROM base AS librespot
 RUN git clone https://github.com/librespot-org/librespot \
    && cd librespot \
-   && git checkout e68bbbf7312eca6dfd2c8b62c9b4b1f460983992
+   && git checkout a211ff94c6c9d11b78964aad91b2a7db1d17d04f
 WORKDIR /librespot
 RUN cargo build --release --no-default-features -j $(( $(nproc) -1 ))
 ###### LIBRESPOT END ######
@@ -56,7 +56,7 @@ FROM base AS snapcast
 ### SNAPSERVER ###
 RUN git clone https://github.com/badaix/snapcast.git /snapcast \
     && cd snapcast \
-    && git checkout c9bdceb1342a5776a21623992885b2f96de3f398 \
+    && git checkout 54a3d86200a52a36ab5cf1d699eee572539db52d \
     && sed -i "s/\-\-use-stderr //" "./server/streamreader/airplay_stream.cpp"
 WORKDIR /snapcast
 RUN cmake -S . -B build -DBUILD_CLIENT=OFF \
@@ -109,7 +109,7 @@ WORKDIR /
 ### SPS ###
 RUN git clone https://github.com/mikebrady/shairport-sync.git /shairport\
     && cd /shairport \
-    && git checkout a6c66db2761619456e80611d2ffc6054684f9caf
+    && git checkout aa1d578bc2b188dbcbb0d07f1b84dbf2dd683314
 WORKDIR /shairport/build
 RUN autoreconf -i ../ \
     && ../configure --sysconfdir=/etc \

--- a/alpine.dockerfile
+++ b/alpine.dockerfile
@@ -45,7 +45,7 @@ RUN git clone https://github.com/librespot-org/librespot \
    && cd librespot \
    && git checkout a211ff94c6c9d11b78964aad91b2a7db1d17d04f
 WORKDIR /librespot
-RUN cargo build --release --no-default-features --features with-dns-sd -j $(( $(nproc) -1 ))
+RUN cargo build --release --no-default-features -j $(( $(nproc) -1 ))
 ###### LIBRESPOT END ######
 
 ###### SNAPCAST BUNDLE START ######
@@ -134,9 +134,6 @@ RUN apk add --no-cache \
             avahi \
             dbus \
             htop \
-            # LIBRESPOT
-            avahi-compat-libdns_sd \
-            libgcc \
             # SNAPCAST
             alsa-lib \
             flac-libs \

--- a/alpine.dockerfile
+++ b/alpine.dockerfile
@@ -38,8 +38,6 @@ RUN apk add --no-cache \
     soxr-dev \
     xmltoman \
     xxd
-# SNAPWEB
-RUN npm install -g typescript@4.9.5
 
 ###### LIBRESPOT START ######
 FROM base AS librespot
@@ -68,8 +66,8 @@ WORKDIR /
 ### SNAPWEB ###
 RUN git clone https://github.com/badaix/snapweb.git
 WORKDIR /snapweb
-RUN git checkout f19a12a3c27d0a4fcbb1058f365f36973c09d033
-RUN make
+RUN git checkout 29f2850fda14bba774db9410d9fb61c7120fa4bb
+RUN npm ci && npm run build
 WORKDIR /
 ### SNAPWEB END ###
 ###### SNAPCAST BUNDLE END ######
@@ -163,7 +161,7 @@ RUN apk add --no-cache \
 # Copy all necessary files from the builders
 COPY --from=librespot /librespot/target/release/librespot /usr/local/bin/
 COPY --from=snapcast /snapcast/bin/snapserver /usr/local/bin/
-COPY --from=snapcast /snapweb/dist /usr/share/snapserver/snapweb
+COPY --from=snapcast /snapweb/build /usr/share/snapserver/snapweb
 COPY --from=shairport /shairport/build/shairport-sync /usr/local/bin/
 COPY --from=shairport /nqptp/nqptp /usr/local/bin/
 COPY --from=shairport /shairport/build/install/etc/shairport-sync.conf /etc/

--- a/alpine.dockerfile
+++ b/alpine.dockerfile
@@ -47,7 +47,7 @@ RUN git clone https://github.com/librespot-org/librespot \
    && cd librespot \
    && git checkout a211ff94c6c9d11b78964aad91b2a7db1d17d04f
 WORKDIR /librespot
-RUN cargo build --release --no-default-features -j $(( $(nproc) -1 ))
+RUN cargo build --release --no-default-features --features with-dns-sd -j $(( $(nproc) -1 ))
 ###### LIBRESPOT END ######
 
 ###### SNAPCAST BUNDLE START ######

--- a/alpine.dockerfile
+++ b/alpine.dockerfile
@@ -57,7 +57,8 @@ FROM base AS snapcast
 RUN git clone https://github.com/badaix/snapcast.git /snapcast \
     && cd snapcast \
     && git checkout 54a3d86200a52a36ab5cf1d699eee572539db52d \
-    && sed -i "s/\-\-use-stderr //" "./server/streamreader/airplay_stream.cpp"
+    && sed -i 's/\-\-use-stderr //' "./server/streamreader/airplay_stream.cpp" \
+    && sed -i 's/LOG(INFO, LOG_TAG) << "Waiting for metadata/LOG(DEBUG, LOG_TAG) << "Waiting for metadata/' "./server/streamreader/airplay_stream.cpp"
 WORKDIR /snapcast
 RUN cmake -S . -B build -DBUILD_CLIENT=OFF \
     && cmake --build build -j $(( $(nproc) -1 )) --verbose
@@ -134,6 +135,7 @@ RUN apk add --no-cache  alsa-lib \
                         avahi-libs \
                         avahi \
                         avahi-tools \
+                        avahi-compat-libdns_sd \
                         dbus \
                         flac \
                         ffmpeg-libs \

--- a/alpine.dockerfile
+++ b/alpine.dockerfile
@@ -66,7 +66,7 @@ WORKDIR /
 ### SNAPWEB ###
 RUN git clone https://github.com/badaix/snapweb.git
 WORKDIR /snapweb
-RUN git checkout 29f2850fda14bba774db9410d9fb61c7120fa4bb
+RUN git checkout a51c67e5fbef9f7f2e5c2f5002db93fcaaac703d
 RUN npm ci && npm run build
 WORKDIR /
 ### SNAPWEB END ###

--- a/alpine.dockerfile
+++ b/alpine.dockerfile
@@ -11,7 +11,6 @@ RUN apk add --no-cache \
     avahi-dev \
     bash \
     boost-dev \
-    boost1.80-dev \
     expat-dev \
     flac-dev \
     git \
@@ -60,8 +59,8 @@ RUN git clone https://github.com/badaix/snapcast.git /snapcast \
     && git checkout c9bdceb1342a5776a21623992885b2f96de3f398 \
     && sed -i "s/\-\-use-stderr //" "./server/streamreader/airplay_stream.cpp"
 WORKDIR /snapcast
-#https://github.com/badaix/snapcast/commit/fdcdf8e350e10374452a091fc8fa9e50641b9e86
-RUN  make HAS_EXPAT=1 -j $(( $(nproc) -1 )) server
+RUN cmake -S . -B build -DBUILD_CLIENT=OFF \
+    && cmake --build build -j $(( $(nproc) -1 )) --verbose
 WORKDIR /
 ### SNAPSERVER END ###
 
@@ -153,12 +152,11 @@ RUN apk add --no-cache  alsa-lib \
                         htop
 # Copy all necessary files from the builders
 COPY --from=librespot /librespot/target/release/librespot /usr/local/bin/
-COPY --from=snapcast /snapcast/server/snapserver /usr/local/bin/
+COPY --from=snapcast /snapcast/bin/snapserver /usr/local/bin/
 COPY --from=snapcast /snapweb/dist /usr/share/snapserver/snapweb
 COPY --from=shairport /shairport/build/shairport-sync /usr/local/bin/
 COPY --from=shairport /nqptp/nqptp /usr/local/bin/
 COPY --from=shairport /shairport/build/install/etc/shairport-sync.conf /etc/
-COPY --from=shairport /shairport/build/install/etc/shairport-sync.conf.sample /etc/
 COPY --from=shairport /usr/local/lib/libalac.* /usr/local/lib/
 COPY --from=shairport /shairport/build/install/etc/dbus-1/system.d/shairport-sync-dbus.conf /etc/dbus-1/system.d/
 COPY --from=shairport /shairport/build/install/etc/dbus-1/system.d/shairport-sync-mpris.conf /etc/dbus-1/system.d/

--- a/alpine.dockerfile
+++ b/alpine.dockerfile
@@ -131,27 +131,35 @@ WORKDIR /
 
 ###### MAIN START ######
 FROM docker.io/crazymax/alpine-s6:3.17-3.1.1.2
-RUN apk add --no-cache  alsa-lib \
-                        avahi-libs \
-                        avahi \
-                        avahi-tools \
-                        avahi-compat-libdns_sd \
-                        dbus \
-                        flac \
-                        ffmpeg-libs \
-                        glib \
-                        libgcc \
-                        libvorbis \
-                        libuuid \
-                        libgcrypt \
-                        libsodium \
-                        libplist \
-                        libconfig \
-                        musl \
-                        opus \
-                        soxr \
-                        popt \
-                        htop
+RUN apk add --no-cache \
+            # COMMON/s6
+            avahi \
+            dbus \
+            htop \
+            # LIBRESPOT
+            avahi-compat-libdns_sd \
+            libgcc \
+            # SNAPCAST
+            alsa-lib \
+            flac-libs \
+            libogg \
+            libvorbis \
+            libstdc++ \
+            libgcc \
+            opus \
+            soxr \
+            # SHAIRPORT
+            ffmpeg-libs \
+            glib \
+            libuuid \
+            libgcrypt \
+            libgcc \
+            libsodium \
+            libplist \
+            libconfig \
+            popt \
+            soxr
+
 # Copy all necessary files from the builders
 COPY --from=librespot /librespot/target/release/librespot /usr/local/bin/
 COPY --from=snapcast /snapcast/bin/snapserver /usr/local/bin/

--- a/debian.dockerfile
+++ b/debian.dockerfile
@@ -1,94 +1,98 @@
-###### LIBRESPOT START ######
-FROM docker.io/debian:bullseye-slim AS librespot
+FROM docker.io/debian:bullseye-slim AS base
 ARG DEBIAN_FRONTEND=noninteractive
 RUN apt-get update \
     && apt-get install --no-install-recommends -y \
-        build-essential \
-        ca-certificates \
-        curl \
-        git \
-        pkg-config \
-        libasound2-dev
+    # LIBRESPOT
+    build-essential \
+    ca-certificates \
+    curl \
+    git \
+    pkg-config \
+    libasound2-dev \
+    # Snapcast
+    build-essential \
+    ca-certificates \
+    cmake \
+    git \
+    npm \
+    libboost-dev \
+    libasound2-dev \
+    libpulse-dev \
+    libvorbisidec-dev \
+    libvorbis-dev \
+    libopus-dev \
+    libflac-dev \
+    libsoxr-dev \
+    libavahi-client-dev \
+    libexpat1-dev \
+    # SHAIRPORT
+    build-essential \
+    ca-certificates \
+    git \
+    autoconf \
+    automake \
+    libglib2.0-dev \
+    libtool \
+    libpopt-dev \
+    libconfig-dev \
+    libasound2-dev \
+    libavahi-client-dev \
+    libssl-dev \
+    libsoxr-dev \
+    libplist-dev \
+    libsodium-dev \
+    libavutil-dev \
+    libavcodec-dev \
+    libavformat-dev \
+    uuid-dev \
+    libgcrypt-dev \
+    xxd
+
+###### LIBRESPOT START ######
+FROM base AS librespot
 RUN curl https://sh.rustup.rs -sSf | sh -s -- -y
 ENV PATH="/root/.cargo/bin/:${PATH}"
+# https://blog.rust-lang.org/inside-rust/2023/01/30/cargo-sparse-protocol.html
+ENV CARGO_REGISTRIES_CRATES_IO_PROTOCOL="sparse"
 RUN git clone https://github.com/librespot-org/librespot \
    && cd librespot \
-   && git checkout e68bbbf7312eca6dfd2c8b62c9b4b1f460983992
+   && git checkout a211ff94c6c9d11b78964aad91b2a7db1d17d04f
 WORKDIR /librespot
 RUN cargo build --release --no-default-features -j $(( $(nproc) -1 ))
 ###### LIBRESPOT END ######
 
-###### SNAPCAST START ######
-FROM docker.io/debian:bullseye-slim AS snapcast
-ARG DEBIAN_FRONTEND=noninteractive
-RUN apt-get update \
-    && apt-get install --no-install-recommends -y \
-        build-essential \
-        ca-certificates \
-        git \
-        npm \
-        libboost-dev \
-        libasound2-dev \
-        libpulse-dev \
-        libvorbisidec-dev \
-        libvorbis-dev \
-        libopus-dev \
-        libflac-dev \
-        libsoxr-dev \
-        libavahi-client-dev \
-        libexpat1-dev
+
+###### SNAPCAST BUNDLE START ######
+FROM base AS snapcast
 
 ### SNAPSERVER ###
 RUN git clone https://github.com/badaix/snapcast.git /snapcast \
     && cd snapcast \
-    && git checkout c9bdceb1342a5776a21623992885b2f96de3f398 \
-    && sed -i "s/\-\-use-stderr //" "./server/streamreader/airplay_stream.cpp"
+    && git checkout 5968f96e11d4abf21e8b50cfe9ae306cdec29d57 \
+    && sed -i 's/\-\-use-stderr //' "./server/streamreader/airplay_stream.cpp" \
+    && sed -i 's/LOG(INFO, LOG_TAG) << "Waiting for metadata/LOG(DEBUG, LOG_TAG) << "Waiting for metadata/' "./server/streamreader/airplay_stream.cpp"
 WORKDIR /snapcast
-RUN  make HAS_EXPAT=1 -j $(( $(nproc) -1 )) server #https://github.com/badaix/snapcast/commit/fdcdf8e350e10374452a091fc8fa9e50641b9e86
+RUN cmake -S . -B build -DBUILD_CLIENT=OFF \
+    && cmake --build build -j $(( $(nproc) -1 )) --verbose
 WORKDIR /
 ### SNAPSERVER END ###
 
 ### SNAPWEB ###
-RUN npm install -g typescript@latest
 RUN git clone https://github.com/badaix/snapweb.git
 WORKDIR /snapweb
-RUN git checkout f19a12a3c27d0a4fcbb1058f365f36973c09d033
-RUN make
+RUN git checkout a51c67e5fbef9f7f2e5c2f5002db93fcaaac703d
+RUN npm ci && npm run build
 WORKDIR /
 ### SNAPWEB END ###
-###### SNAPCAST END ######
+###### SNAPCAST BUNDLE END ######
 
-###### SHAIRPORT START ######
-FROM docker.io/debian:bullseye-slim AS shairport
-ARG DEBIAN_FRONTEND=noninteractive
-RUN apt-get update \
-    && apt-get install --no-install-recommends -y \
-        build-essential \
-        ca-certificates \
-        git \
-        autoconf \
-        automake \
-        libglib2.0-dev \
-        libtool \
-        libpopt-dev \
-        libconfig-dev \
-        libasound2-dev \
-        libavahi-client-dev \
-        libssl-dev \
-        libsoxr-dev \
-        libplist-dev \
-        libsodium-dev \
-        libavutil-dev \
-        libavcodec-dev \
-        libavformat-dev \
-        uuid-dev \
-        libgcrypt-dev \
-        xxd
+###### SHAIRPORT BUNDLE START ######
+FROM base AS shairport
 
 ### NQPTP ###
 RUN git clone https://github.com/mikebrady/nqptp
 WORKDIR /nqptp
-RUN git checkout 845219c74cd0e35cd344da9f0a37c6e7d3e576f2 \
+RUN git checkout 576273509779f31b9e8b4fa32087dea7105fa8c7 \
     && autoreconf -i \
     && ./configure \
     && make -j $(( $(nproc) -1 ))
@@ -106,10 +110,19 @@ RUN git checkout 96dd59d17b776a7dc94ed9b2c2b4a37177feb3c4 \
 WORKDIR /
 ### ALAC END ###
 
+### METADATA-READER START ###
+RUN git clone https://github.com/mikebrady/shairport-sync-metadata-reader.git
+WORKDIR /shairport-sync-metadata-reader
+RUN autoreconf -i -f \
+    && ./configure \
+    && make
+WORKDIR /
+### METADATA-READER END ###
+
 ### SPS ###
 RUN git clone https://github.com/mikebrady/shairport-sync.git /shairport\
     && cd /shairport \
-    && git checkout a6c66db2761619456e80611d2ffc6054684f9caf
+    && git checkout a1c9387ca81bedebb986e237403db0cd57ae45dc
 WORKDIR /shairport/build
 RUN autoreconf -i ../ \
     && ../configure --sysconfdir=/etc \
@@ -126,7 +139,7 @@ RUN autoreconf -i ../ \
     && DESTDIR=install make -j $(( $(nproc) -1 )) install
 WORKDIR /
 ### SPS END ###
-###### SHAIRPORT END ######
+###### SHAIRPORT BUNDLE END ######
 
 ###### MAIN START ######
 FROM docker.io/debian:bullseye-slim
@@ -151,6 +164,7 @@ RUN apt-get update \
         libplist3 \
         libconfig9 \
         libpopt0 \
+        libnss-mdns\
     && apt-get clean
 
 ADD https://github.com/just-containers/s6-overlay/releases/download/v${S6_OVERLAY_VERSION}/s6-overlay-noarch.tar.xz /tmp
@@ -161,8 +175,8 @@ RUN tar -C / -Jxpf /tmp/s6-overlay-x86_64.tar.xz
 
 # Copy all necessary files from the builders
 COPY --from=librespot /librespot/target/release/librespot /usr/local/bin/
-COPY --from=snapcast /snapcast/server/snapserver /usr/local/bin/
-COPY --from=snapcast /snapweb/dist /usr/share/snapserver/snapweb
+COPY --from=snapcast /snapcast/bin/snapserver /usr/local/bin/
+COPY --from=snapcast /snapweb/build /usr/share/snapserver/snapweb
 COPY --from=shairport /shairport/build/shairport-sync /usr/local/bin/
 COPY --from=shairport /nqptp/nqptp /usr/local/bin/
 COPY --from=shairport /shairport/build/install/etc/shairport-sync.conf /etc/
@@ -183,4 +197,5 @@ RUN addgroup shairport-sync \
 
 RUN mkdir /run/dbus
 
+ENTRYPOINT ["/init"]
 ###### MAIN END ######

--- a/debian.dockerfile
+++ b/debian.dockerfile
@@ -78,10 +78,16 @@ WORKDIR /
 ### SNAPSERVER END ###
 
 ### SNAPWEB ###
+# Upgrade node.js to 16.x
+RUN curl -fsSL https://deb.nodesource.com/setup_16.x | bash - \
+    && apt-get install --no-install-recommends -y nodejs
 RUN git clone https://github.com/badaix/snapweb.git
 WORKDIR /snapweb
 RUN git checkout a51c67e5fbef9f7f2e5c2f5002db93fcaaac703d
-RUN npm ci && npm run build
+ENV GENERATE_SOURCEMAP="false"
+RUN npm ci \
+    && npm install \
+    && npm run build
 WORKDIR /
 ### SNAPWEB END ###
 ###### SNAPCAST BUNDLE END ######

--- a/s6-overlay/s6-rc.d/03-avahi/run
+++ b/s6-overlay/s6-rc.d/03-avahi/run
@@ -1,4 +1,5 @@
 #!/command/with-contenv sh
+# For Debian use path 'run/dbus/pid'
 while [ ! -f /var/run/dbus/dbus.pid ]; do
   echo "s6-rc: warning: dbus is not running, sleeping for 1 seconds before trying to start avahi"
   sleep 1


### PR DESCRIPTION
- Update `actions/checkout` to `v3.4.0`
- Install cargo from edge on `alpine` to be able to use `CARGO_REGISTRIES_CRATES_IO_PROTOCOL="sparse"`
- Patch log level of `snapcast` `Waiting for metadata` from `INFO` to `DEBUG` to reduce logspam
- Build `snapcast` via `cmake` instead of `make`
- Switch to `react` branch of `snapweb`
- Update Debian dockerfie
- Update components
`librespot`: `a211ff94c6c9d11b78964aad91b2a7db1d17d04f`
`snapcast`: `5968f96e11d4abf21e8b50cfe9ae306cdec29d57`
`snapweb`: `a51c67e5fbef9f7f2e5c2f5002db93fcaaac703d`
`nqptp`: `576273509779f31b9e8b4fa32087dea7105fa8c7`
`shairport-sync`: `a1c9387ca81bedebb986e237403db0cd57ae45dc`