### PR TITLE
Switch to Debian based images

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -7,4 +7,4 @@ updates:
     day: sunday
     time: "10:00"
   open-pull-requests-limit: 10
-  target-branch: master
+  target-branch: development

--- a/.github/workflows/publish_images.yml
+++ b/.github/workflows/publish_images.yml
@@ -49,7 +49,7 @@ jobs:
         uses: docker/build-push-action@v4.0.0
         with:
           context: .
-          file: ./alpine.dockerfile
+          file: ./debian.dockerfile
           platforms: linux/amd64
           push: ${{ github.event_name != 'pull_request' }}
           cache-from: type=gha

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # librespot-shairport-snapserver
 
-Alpine based Docker image for running the [snapserver part of snapcast](https://github.com/badaix/snapcast) with
+Debian based Docker image for running the [snapserver part of snapcast](https://github.com/badaix/snapcast) with
 [librespot](https://github.com/librespot-org/librespot) and [shairport-sync](https://github.com/mikebrady/shairport-sync) as input.
 
 Idea adapted from [librespot-snapserver](https://github.com/djmaze/librespot-snapserver) and based on [shairport-sync docker image](https://github.com/mikebrady/shairport-sync/tree/master/docker)
@@ -27,20 +27,22 @@ docker run -d --rm --net host --name snapserver librespot-shairport-snapserver
 or with `docker-compose.yml`
 
 ```yml
-version: "3"
 services:
   snapcast:
     image: ghcr.io/yubiuser/yubiuser/librespot-shairport-snapserver
     container_name: snapcast
     restart: unless-stopped
     network_mode: host
+    volumes:
+     - ./snapserver.conf:/etc/snapserver.conf
+     - /tmp/snapfifo:/tmp/snapfifo
 ```
 
 ### Build locally
 
 To build the image simply run
 
-`docker build -t librespot-shairport-snapserver:local -f ./alpine.dockerfile .`
+`docker build -t librespot-shairport-snapserver:local -f ./debian.dockerfile .`
 
 Start the container with
 
@@ -48,17 +50,18 @@ Start the container with
 
 ## Notes
 
-- Based on current Alpine version 3:17
-- Final image size is ~190 MB
+- Based on current Debian Bullseye
+- Final image size is ~330 MB
 - All `(c)make` calles use the option `-j $(( $(nproc) -1 ))` to leave one CPU for normal operation
 - Compiling `snapserver`
   - A deprecated option needs to be removed on the `airplay-stream.cpp`
+  - Logging of information of the `airplay-stream` metadata handler has been modified from `info` to `debug` to reduce logspam
 - `s6-overlay` is used as `init` system (same as the [shairport-sync docker image](https://github.com/mikebrady/shairport-sync/tree/master/docker)). This is necessary, because *shairport-sync* needs a companion application called [NQPTP](https://github.com/mikebrady/nqptp) which needs to be started from `root` to run as deamon.
-  - The `ENTRYPOINT ["/init"]` is set within the [docker-alpine-s6 base image](https://github.com/crazy-max/docker-alpine-s6) already
   - `s6-rc` with configured dependencies is used to start all services. `snapserver` should start as last
   - `s6-rc` considers *longrun* services as "started" when the `run` file is executed. However, some services need a bit time to fully startup. To not breake dependent services, they check for existence of `*.pid` files of previous services
 - Adjust `snapserver.conf` as required (Airplay 2 needs port 7000)
 - [Snapweb](https://github.com/badaix/snapweb) is inclued in the image and can be accessed on `http://<snapserver host>:1780`
 - `hop`  is included for debugging purposes
 - `shairport-sync-metadata-reader` is inclued for debuging purposes
-- I tried to provide multi-arch images as well, however, cross-compiling/building on Github with `QEMU` and `buildx` took hours and was canceled a few times automatically. I tried with a Debian based images as well, but no avail. The `debian.dockerfile` should provide a usable image with only minor necesary changes to the `s6` files. Debian images are ~334 MB.
+- I tried to provide multi-arch images as well, however, cross-compiling/building on Github with `QEMU` and `buildx` took hours and was canceled a few times automatically.
+- The `alpine.dockerfile` should provide a usable image with only minor necesary changes to the `s6` files. Alpine images are ~190 MB. However, I had issues with `mDNS` on Alpine so I switched to the Debian based images.

--- a/debian.dockerfile
+++ b/debian.dockerfile
@@ -7,6 +7,7 @@ RUN apt-get update \
     ca-certificates \
     curl \
     git \
+    libavahi-compat-libdnssd-dev \
     pkg-config \
     libasound2-dev \
     # Snapcast
@@ -56,9 +57,9 @@ ENV PATH="/root/.cargo/bin/:${PATH}"
 ENV CARGO_REGISTRIES_CRATES_IO_PROTOCOL="sparse"
 RUN git clone https://github.com/librespot-org/librespot \
    && cd librespot \
-   && git checkout a211ff94c6c9d11b78964aad91b2a7db1d17d04f
+   && git checkout 7de8bdc0f3a4b726e921da2fb4c4a1726b98183c
 WORKDIR /librespot
-RUN cargo build --release --no-default-features -j $(( $(nproc) -1 ))
+RUN cargo build --release --no-default-features --features with-dns-sd -j $(( $(nproc) -1 ))
 ###### LIBRESPOT END ######
 
 
@@ -83,10 +84,10 @@ RUN curl -fsSL https://deb.nodesource.com/setup_16.x | bash - \
     && apt-get install --no-install-recommends -y nodejs
 RUN git clone https://github.com/badaix/snapweb.git
 WORKDIR /snapweb
-RUN git checkout a51c67e5fbef9f7f2e5c2f5002db93fcaaac703d
+RUN git checkout 0df63b98505aaad55a1cf588176249dd5036b467
 ENV GENERATE_SOURCEMAP="false"
-RUN npm ci \
-    && npm install \
+RUN npm install -g npm@latest \
+    && npm ci \
     && npm run build
 WORKDIR /
 ### SNAPWEB END ###
@@ -128,7 +129,7 @@ WORKDIR /
 ### SPS ###
 RUN git clone https://github.com/mikebrady/shairport-sync.git /shairport\
     && cd /shairport \
-    && git checkout a1c9387ca81bedebb986e237403db0cd57ae45dc
+    && git checkout 1b53d9d3068fcc39ec8a286f01312e4fc54cb1e4
 WORKDIR /shairport/build
 RUN autoreconf -i ../ \
     && ../configure --sysconfdir=/etc \
@@ -149,7 +150,7 @@ WORKDIR /
 
 ###### MAIN START ######
 FROM docker.io/debian:bullseye-slim
-ARG S6_OVERLAY_VERSION=3.1.3.0
+ARG S6_OVERLAY_VERSION=3.1.4.1
 ARG DEBIAN_FRONTEND=noninteractive
 RUN apt-get update \
     && apt-get install --no-install-recommends -y \
@@ -171,6 +172,7 @@ RUN apt-get update \
         libconfig9 \
         libpopt0 \
         libnss-mdns\
+        libavahi-compat-libdnssd1 \
     && apt-get clean
 
 ADD https://github.com/just-containers/s6-overlay/releases/download/v${S6_OVERLAY_VERSION}/s6-overlay-noarch.tar.xz /tmp

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,9 @@
+services:
+  snapcast:
+    image: ghcr.io/yubiuser/yubiuser/librespot-shairport-snapserver:latest
+    container_name: snapcast
+    restart: unless-stopped
+    network_mode: host
+    volumes:
+     - ./snapserver.conf:/etc/snapserver.conf
+     - /tmp/snapfifo:/tmp/snapfifo

--- a/s6-overlay/s6-rc.d/03-avahi/run
+++ b/s6-overlay/s6-rc.d/03-avahi/run
@@ -1,6 +1,6 @@
 #!/command/with-contenv sh
-# For Debian use path 'run/dbus/pid'
-while [ ! -f /var/run/dbus/dbus.pid ]; do
+# For Alpine use path '/var/run/dbus/dbus.pid'
+while [ ! -f /run/dbus/pid ]; do
   echo "s6-rc: warning: dbus is not running, sleeping for 1 seconds before trying to start avahi"
   sleep 1
 done

--- a/snapserver.conf
+++ b/snapserver.conf
@@ -137,6 +137,7 @@ doc_root = /usr/share/snapserver/snapweb
 
 source = airplay:///shairport-sync?name=Airplay&devicename=Snapcast&port=7000
 source = spotify:///librespot?name=Spotify&bitrate=320&volume=75&normalize
+source = pipe:///tmp/snapfifo?name=Bluetooth&mode=read&sampleformat=44100:16:2
 
 # Default sample format: <sample rate>:<bits per sample>:<channels>
 #sampleformat = 48000:16:2


### PR DESCRIPTION
As I had issues with `mDNS` on the Alpine images this PR switched to Debian based images. (Bonus: image building is faster)

- Use Debian based images by default
- Use `with-dns-sd` compile flag of `librespot`
- Set Dependabot to target `development` instead of `master`
- Add sample `docker-compose` file
- Add Bluetooth source in `snapserver.conf`
- Update `s6-overlay` to `3.1.4.1`
- Update `shairport-sync` to `1b53d9d3068fcc39ec8a286f01312e4fc54cb1e4`
- Update `librespot` to `7de8bdc0f3a4b726e921da2fb4c4a1726b98183c`