### PR TITLE
Improve Rust compilation time and switch to Debian Bookworm

### DIFF
--- a/.github/workflows/publish_images.yml
+++ b/.github/workflows/publish_images.yml
@@ -18,7 +18,7 @@ jobs:
 
       - name: Revert CPU limit
         run: |
-          sed -i 's/(( \$(nproc) -1 ))/(nproc)/g' './alpine.dockerfile'
+          sed -i 's/(( \$(nproc) -1 ))/(nproc)/g' './alpine.dockerfile' './debian.dockerfile'
 
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v2.5.0

--- a/README.md
+++ b/README.md
@@ -50,8 +50,8 @@ Start the container with
 
 ## Notes
 
-- Based on current Debian Bullseye
-- Final image size is ~330 MB
+- Based on current Debian Bookworm
+- Final image size is ~365 MB
 - All `(c)make` calles use the option `-j $(( $(nproc) -1 ))` to leave one CPU for normal operation
 - Compiling `snapserver`
   - A deprecated option needs to be removed on the `airplay-stream.cpp`


### PR DESCRIPTION
- Revert CPU limit in workflows for both Alpine and Debian dockerfile
- Switch to Debian Bookworm 
  - allows to use `mold` as linker for `librespot` compilation#
  - makes downloading `nodejs` `v16` obsolet (v18 is included in the repos)
- install `rust` with `minimal` profile
- set `CARGO_INCREMENTAL=0` as we are building on CI and won't re-use incremental builds