### PR TITLE
Release v2.0.0

### DIFF
--- a/.github/workflows/publish_images.yml
+++ b/.github/workflows/publish_images.yml
@@ -49,7 +49,7 @@ jobs:
         uses: docker/build-push-action@v4.0.0
         with:
           context: .
-          file: ./debian.dockerfile
+          file: ./alpine.dockerfile
           platforms: linux/amd64
           push: ${{ github.event_name != 'pull_request' }}
           cache-from: type=gha

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # librespot-shairport-snapserver
 
-Debian based Docker image for running the [snapserver part of snapcast](https://github.com/badaix/snapcast) with
+Alpine based Docker image for running the [snapserver part of snapcast](https://github.com/badaix/snapcast) with
 [librespot](https://github.com/librespot-org/librespot) and [shairport-sync](https://github.com/mikebrady/shairport-sync) as input.
 
 Idea adapted from [librespot-snapserver](https://github.com/djmaze/librespot-snapserver) and based on [shairport-sync docker image](https://github.com/mikebrady/shairport-sync/tree/master/docker)
@@ -9,7 +9,7 @@ Idea adapted from [librespot-snapserver](https://github.com/djmaze/librespot-sna
  Same for *librespot*, last release is v0.46 from 07/2022 which is missing 266 commits compared to `dev`.
  Therefore, everything is compiled from source.
 
- **Note:** Current last commit of the development branches for all repos are used to compile the lastest versions.
+ **Note:** Current last commit of the respective development branches for all repos are used to compile the lastest versions.
 
  **Note** The coresponding Docker image for runinng `snapclient` can be found here: [https://github.com/yubiuser/snapclient-docker](https://github.com/yubiuser/snapclient-docker)
 
@@ -21,7 +21,7 @@ Use with
 
 ```plain
 docker pull ghcr.io/yubiuser/librespot-shairport-snapserver
-docker run -d --rm --net host --name snapserver librespot-shairport-snapserver
+docker run -d --rm --net host -v ./snapserver.conf:/etc/snapserver.conf --name snapserver librespot-shairport-snapserver
 ```
 
 or with `docker-compose.yml`
@@ -35,33 +35,26 @@ services:
     network_mode: host
     volumes:
      - ./snapserver.conf:/etc/snapserver.conf
-     - /tmp/snapfifo:/tmp/snapfifo
+     #- /tmp/snapfifo:/tmp/snapfifo
 ```
 
 ### Build locally
 
 To build the image simply run
 
-`docker build -t librespot-shairport-snapserver:local -f ./debian.dockerfile .`
+`docker build -t librespot-shairport-snapserver:local -f ./alpine.dockerfile .`
 
-Start the container with
-
-`docker run -d --rm --net host --name librespot-shairport-snapserver librespot-shairport-snapserver:local`
 
 ## Notes
 
-- Based on current Debian Bookworm
-- Final image size is ~365 MB
+- Based on Alpine 3:18; final image size is ~116MB
 - All `(c)make` calles use the option `-j $(( $(nproc) -1 ))` to leave one CPU for normal operation
 - Compiling `snapserver`
   - A deprecated option needs to be removed on the `airplay-stream.cpp`
   - Logging of information of the `airplay-stream` metadata handler has been modified from `info` to `debug` to reduce logspam
 - `s6-overlay` is used as `init` system (same as the [shairport-sync docker image](https://github.com/mikebrady/shairport-sync/tree/master/docker)). This is necessary, because *shairport-sync* needs a companion application called [NQPTP](https://github.com/mikebrady/nqptp) which needs to be started from `root` to run as deamon.
   - `s6-rc` with configured dependencies is used to start all services. `snapserver` should start as last
-  - `s6-rc` considers *longrun* services as "started" when the `run` file is executed. However, some services need a bit time to fully startup. To not breake dependent services, they check for existence of `*.pid` files of previous services
+  - `s6-notifyoncheck` is used to check readiness of the started services `dbus` and `avahi`. The actual check is performed by sending `dbus`messages and analyzing the reply.
 - Adjust `snapserver.conf` as required (Airplay 2 needs port 7000)
 - [Snapweb](https://github.com/badaix/snapweb) is inclued in the image and can be accessed on `http://<snapserver host>:1780`
-- `hop`  is included for debugging purposes
-- `shairport-sync-metadata-reader` is inclued for debuging purposes
-- I tried to provide multi-arch images as well, however, cross-compiling/building on Github with `QEMU` and `buildx` took hours and was canceled a few times automatically.
-- The `alpine.dockerfile` should provide a usable image with only minor necesary changes to the `s6` files. Alpine images are ~190 MB. However, I had issues with `mDNS` on Alpine so I switched to the Debian based images.
+- An alternative Debian based image (Bookworm) is offered, final image size is ~262 MB

--- a/alpine.dockerfile
+++ b/alpine.dockerfile
@@ -143,7 +143,7 @@ RUN mkdir /shairport-libs \
 
 ###### BASE START ######
 FROM docker.io/alpine:3.17 as base
-ARG S6_OVERLAY_VERSION=3.1.4.1
+ARG S6_OVERLAY_VERSION=3.1.5.0
 RUN apk add --no-cache \
     fdupes
 # Copy all necessary libaries into one directory to avoid carring over duplicates

--- a/alpine.dockerfile
+++ b/alpine.dockerfile
@@ -151,7 +151,7 @@ RUN apk add --no-cache \
 COPY --from=librespot /librespot-libs/ /tmp-libs/
 COPY --from=snapcast /snapserver-libs/ /tmp-libs/
 COPY --from=shairport /shairport-libs/ /tmp-libs/
-RUN fdupes -d -N /tmp-libs/ /lib/x86_64-linux-gnu/
+RUN fdupes -d -N /tmp-libs/ /usr/lib/
 
 # Install s6
 ADD https://github.com/just-containers/s6-overlay/releases/download/v${S6_OVERLAY_VERSION}/s6-overlay-noarch.tar.xz \

--- a/alpine.dockerfile
+++ b/alpine.dockerfile
@@ -2,6 +2,7 @@ FROM docker.io/alpine:3.17 as base
 RUN apk add --no-cache \
     # LIBRESPOT
     git \
+    mold \
     musl-dev\
     pkgconfig \
     # SNAPCAST
@@ -40,15 +41,24 @@ RUN apk add --no-cache \
 
 ###### LIBRESPOT START ######
 FROM base AS librespot
-# Install cargo/rust from 'edge' as it is v1.68 which uses the new "sparse" protocol which speeds up the cargo index update massively
+# Use faster 'mold' linker from 'edge'
+RUN apk add --no-cache llvm16-libs --repository=https://dl-cdn.alpinelinux.org/alpine/edge/main
+ENV RUSTFLAGS="-C link-args=-fuse-ld=mold -C strip=symbols"
+# Install cargo/rust from 'edge' as it is >= v1.68 which uses the new "sparse" protocol which speeds up the cargo index update massively
 RUN apk add --no-cache cargo --repository=https://dl-cdn.alpinelinux.org/alpine/edge/community
 # https://blog.rust-lang.org/inside-rust/2023/01/30/cargo-sparse-protocol.html
 ENV CARGO_REGISTRIES_CRATES_IO_PROTOCOL="sparse"
+# Disable incremental compilation
+ENV CARGO_INCREMENTAL=0
 RUN git clone https://github.com/librespot-org/librespot \
    && cd librespot \
-   && git checkout a211ff94c6c9d11b78964aad91b2a7db1d17d04f
+   && git checkout e4d476533203b734335a07bd0342fabb9ac34f42
 WORKDIR /librespot
-RUN cargo build --release --no-default-features -j $(( $(nproc) -1 ))
+RUN cargo build --release --no-default-features --features with-dns-sd -j $(( $(nproc) -1 ))
+
+# Gather all shared libaries necessary to run the executable
+RUN mkdir /librespot-libs \
+    && ldd /librespot/target/release/librespot | cut -d" " -f3 | xargs cp --dereference --target-directory=/librespot-libs/
 ###### LIBRESPOT END ######
 
 ###### SNAPCAST BUNDLE START ######
@@ -62,7 +72,8 @@ RUN git clone https://github.com/badaix/snapcast.git /snapcast \
     && sed -i 's/LOG(INFO, LOG_TAG) << "Waiting for metadata/LOG(DEBUG, LOG_TAG) << "Waiting for metadata/' "./server/streamreader/airplay_stream.cpp"
 WORKDIR /snapcast
 RUN cmake -S . -B build -DBUILD_CLIENT=OFF \
-    && cmake --build build -j $(( $(nproc) -1 )) --verbose
+    && cmake --build build -j $(( $(nproc) -1 )) --verbose \
+    && strip -s ./bin/snapserver
 WORKDIR /
 ### SNAPSERVER END ###
 
@@ -73,6 +84,10 @@ RUN git checkout a51c67e5fbef9f7f2e5c2f5002db93fcaaac703d
 RUN npm ci && npm run build
 WORKDIR /
 ### SNAPWEB END ###
+
+# Gather all shared libaries necessary to run the executable
+RUN mkdir /snapserver-libs \
+    && ldd /snapcast/bin/snapserver | cut -d" " -f3 | xargs cp --dereference --target-directory=/snapserver-libs/
 ###### SNAPCAST BUNDLE END ######
 
 ###### SHAIRPORT BUNDLE START ######
@@ -99,15 +114,6 @@ RUN git checkout 96dd59d17b776a7dc94ed9b2c2b4a37177feb3c4 \
 WORKDIR /
 ### ALAC END ###
 
-### METADATA-READER START ###
-RUN git clone https://github.com/mikebrady/shairport-sync-metadata-reader.git
-WORKDIR /shairport-sync-metadata-reader
-RUN autoreconf -i -f \
-    && ./configure \
-    && make
-WORKDIR /
-### METADATA-READER END ###
-
 ### SPS ###
 RUN git clone https://github.com/mikebrady/shairport-sync.git /shairport\
     && cd /shairport \
@@ -120,43 +126,24 @@ RUN autoreconf -i ../ \
                     --with-ssl=openssl \
                     --with-airplay-2 \
                     --with-stdout \
-                    --with-pipe \
                     --with-metadata \
                     --with-apple-alac \
-                    --with-dbus-interface \
-                    --with-mpris-interface \
     && DESTDIR=install make -j $(( $(nproc) -1 )) install
+
 WORKDIR /
+
+# Gather all shared libaries necessary to run the executable
+RUN mkdir /shairport-libs \
+    && ldd /shairport/build/shairport-sync | cut -d" " -f3 | xargs cp --dereference --target-directory=/shairport-libs/
 ### SPS END ###
 ###### SHAIRPORT BUNDLE END ######
 
 ###### MAIN START ######
 FROM docker.io/crazymax/alpine-s6:3.17-3.1.1.2
 RUN apk add --no-cache \
-            # COMMON/s6
             avahi \
             dbus \
-            htop \
-            # SNAPCAST
-            alsa-lib \
-            flac-libs \
-            libogg \
-            libvorbis \
-            libstdc++ \
-            libgcc \
-            opus \
-            soxr \
-            # SHAIRPORT
-            ffmpeg-libs \
-            glib \
-            libuuid \
-            libgcrypt \
-            libgcc \
-            libsodium \
-            libplist \
-            libconfig \
-            popt \
-            soxr
+    && rm -rf /lib/apk/db/*
 
 # Copy all necessary files from the builders
 COPY --from=librespot /librespot/target/release/librespot /usr/local/bin/
@@ -164,20 +151,15 @@ COPY --from=snapcast /snapcast/bin/snapserver /usr/local/bin/
 COPY --from=snapcast /snapweb/build /usr/share/snapserver/snapweb
 COPY --from=shairport /shairport/build/shairport-sync /usr/local/bin/
 COPY --from=shairport /nqptp/nqptp /usr/local/bin/
-COPY --from=shairport /shairport/build/install/etc/shairport-sync.conf /etc/
 COPY --from=shairport /usr/local/lib/libalac.* /usr/local/lib/
-COPY --from=shairport /shairport/build/install/etc/dbus-1/system.d/shairport-sync-dbus.conf /etc/dbus-1/system.d/
-COPY --from=shairport /shairport/build/install/etc/dbus-1/system.d/shairport-sync-mpris.conf /etc/dbus-1/system.d/
-COPY --from=shairport /shairport-sync-metadata-reader/shairport-sync-metadata-reader  /usr/local/bin/shairport-sync-metadata-reader
+
+COPY --from=librespot /librespot-libs/ /usr/lib/
+COPY --from=snapcast /snapserver-libs/ /usr/lib/
+COPY --from=shairport /shairport-libs/ /usr/lib/
 
 # Copy local files
 COPY snapserver.conf /etc/snapserver.conf
 COPY ./s6-overlay/s6-rc.d /etc/s6-overlay/s6-rc.d
 RUN chmod +x /etc/s6-overlay/s6-rc.d/01-startup/script.sh
-
-# Create non-root user for running the container -- running as the user 'shairport-sync' also allows
-# Shairport Sync to provide the D-Bus and MPRIS interfaces within the container
-RUN addgroup shairport-sync \
-    && adduser -D shairport-sync -G shairport-sync
 
 ###### MAIN END ######

--- a/alpine.dockerfile
+++ b/alpine.dockerfile
@@ -52,7 +52,7 @@ ENV CARGO_REGISTRIES_CRATES_IO_PROTOCOL="sparse"
 ENV CARGO_INCREMENTAL=0
 RUN git clone https://github.com/librespot-org/librespot \
    && cd librespot \
-   && git checkout e4d476533203b734335a07bd0342fabb9ac34f42
+   && git checkout 31d18f7e30b1e680bc8c56c0f5144ccb6f9f6aab
 WORKDIR /librespot
 RUN cargo build --release --no-default-features --features with-dns-sd -j $(( $(nproc) -1 ))
 
@@ -67,7 +67,7 @@ FROM builder AS snapcast
 ### SNAPSERVER ###
 RUN git clone https://github.com/badaix/snapcast.git /snapcast \
     && cd snapcast \
-    && git checkout 5968f96e11d4abf21e8b50cfe9ae306cdec29d57 \
+    && git checkout 481f08199ca31c60c9a3475f1064e6b06a503d12 \
     && sed -i 's/\-\-use-stderr //' "./server/streamreader/airplay_stream.cpp" \
     && sed -i 's/LOG(INFO, LOG_TAG) << "Waiting for metadata/LOG(DEBUG, LOG_TAG) << "Waiting for metadata/' "./server/streamreader/airplay_stream.cpp"
 WORKDIR /snapcast
@@ -99,7 +99,7 @@ FROM builder AS shairport
 ### NQPTP ###
 RUN git clone https://github.com/mikebrady/nqptp
 WORKDIR /nqptp
-RUN git checkout f125856089d71b6a37a284d3a0e6f0e6cc986058 \
+RUN git checkout 5471c6c828e6dc19f24ff7106a042e4f5b3d604f \
     && autoreconf -i \
     && ./configure \
     && make -j $(( $(nproc) -1 ))
@@ -120,7 +120,7 @@ WORKDIR /
 ### SPS ###
 RUN git clone https://github.com/mikebrady/shairport-sync.git /shairport\
     && cd /shairport \
-    && git checkout 32fddbfdc775069fb4f2898ff8b7f8d97d63ac53
+    && git checkout 6e7f40a7f1535a2b6da64c27fe8d3875c0294c67
 WORKDIR /shairport/build
 RUN autoreconf -i ../ \
     && ../configure --sysconfdir=/etc \

--- a/debian.dockerfile
+++ b/debian.dockerfile
@@ -61,7 +61,7 @@ ENV CARGO_REGISTRIES_CRATES_IO_PROTOCOL="sparse"
 # Disable incremental compilation
 ENV CARGO_INCREMENTAL=0
 # Use faster 'mold' linker
-ENV RUSTFLAGS="-C link-args=-fuse-ld=mold"
+ENV RUSTFLAGS="-C link-args=-fuse-ld=mold -C strip=symbols"
 RUN git clone https://github.com/librespot-org/librespot \
    && cd librespot \
    && git checkout e4d476533203b734335a07bd0342fabb9ac34f42

--- a/debian.dockerfile
+++ b/debian.dockerfile
@@ -64,7 +64,7 @@ ENV CARGO_INCREMENTAL=0
 ENV RUSTFLAGS="-C link-args=-fuse-ld=mold -C strip=symbols"
 RUN git clone https://github.com/librespot-org/librespot \
    && cd librespot \
-   && git checkout e4d476533203b734335a07bd0342fabb9ac34f42
+   && git checkout 31d18f7e30b1e680bc8c56c0f5144ccb6f9f6aab
 WORKDIR /librespot
 RUN cargo build --release --no-default-features --features with-dns-sd -j $(( $(nproc) -1 ))
 
@@ -79,7 +79,7 @@ FROM builder AS snapcast
 ### SNAPSERVER ###
 RUN git clone https://github.com/badaix/snapcast.git /snapcast \
     && cd snapcast \
-    && git checkout 5968f96e11d4abf21e8b50cfe9ae306cdec29d57 \
+    && git checkout 481f08199ca31c60c9a3475f1064e6b06a503d12 \
     && sed -i 's/\-\-use-stderr //' "./server/streamreader/airplay_stream.cpp" \
     && sed -i 's/LOG(INFO, LOG_TAG) << "Waiting for metadata/LOG(DEBUG, LOG_TAG) << "Waiting for metadata/' "./server/streamreader/airplay_stream.cpp"
 WORKDIR /snapcast
@@ -111,7 +111,7 @@ FROM builder AS shairport
 ### NQPTP ###
 RUN git clone https://github.com/mikebrady/nqptp
 WORKDIR /nqptp
-RUN git checkout f125856089d71b6a37a284d3a0e6f0e6cc986058 \
+RUN git checkout 5471c6c828e6dc19f24ff7106a042e4f5b3d604f \
     && autoreconf -i \
     && ./configure \
     && make -j $(( $(nproc) -1 ))
@@ -133,7 +133,7 @@ RUN cp /usr/local/lib/libalac.* /usr/lib/
 ### SPS ###
 RUN git clone https://github.com/mikebrady/shairport-sync.git /shairport\
     && cd /shairport \
-    && git checkout 32fddbfdc775069fb4f2898ff8b7f8d97d63ac53
+    && git checkout 6e7f40a7f1535a2b6da64c27fe8d3875c0294c67
 WORKDIR /shairport/build
 RUN autoreconf -i ../ \
     && ../configure --sysconfdir=/etc \

--- a/debian.dockerfile
+++ b/debian.dockerfile
@@ -156,7 +156,7 @@ RUN mkdir /shairport-libs \
 
 ###### BASE START ######
 FROM docker.io/debian:bookworm-slim as base
-ARG S6_OVERLAY_VERSION=3.1.4.1
+ARG S6_OVERLAY_VERSION=3.1.5.0
 RUN apt-get update \
     && apt-get install --no-install-recommends -y \
         fdupes \

--- a/debian.dockerfile
+++ b/debian.dockerfile
@@ -81,7 +81,8 @@ RUN git clone https://github.com/badaix/snapcast.git /snapcast \
     && sed -i 's/LOG(INFO, LOG_TAG) << "Waiting for metadata/LOG(DEBUG, LOG_TAG) << "Waiting for metadata/' "./server/streamreader/airplay_stream.cpp"
 WORKDIR /snapcast
 RUN cmake -S . -B build -DBUILD_CLIENT=OFF \
-    && cmake --build build -j $(( $(nproc) -1 )) --verbose
+    && cmake --build build -j $(( $(nproc) -1 )) --verbose \
+    && strip -s ./bin/snapserver
 WORKDIR /
 ### SNAPSERVER END ###
 


### PR DESCRIPTION
New major release

Instead of installing all required (lib)packages with their own dependencies in the final image, a different approach is now used:
Each build binary is checked for needed shared libraries and those files are copied to a dedicated directory. The directories are copied over into a `base` build stage into a common directory (to reduce duplicates) and checked against the libraries that are installed with the base image. Everything that is not needed is deleted. Finally, the remaining libs are copied into the final image.
This approach reduces the image sizes significantly. Together with the below changes the final images are 80-100MB smaller than before.

Additionally
- Binaries are stripped from debug symboles
- Update Alpine image to v3:18
- Use Alpine image as default for publishing
- `s6-overlay` is updated to 3.1.5.0
- `s6-overlay` is downloaded and unpacked in the `base` stage - this saves a few MB in the final image
- librespot is updated to `31d18f7e30b1e680bc8c56c0f5144ccb6f9f6aab`
- snapcast is updated to `481f08199ca31c60c9a3475f1064e6b06a503d12`
- nqptp is updated to `5471c6c828e6dc19f24ff7106a042e4f5b3d604f`
- shairport-sync is updated to `6e7f40a7f1535a2b6da64c27fe8d3875c0294c67`