### PR TITLE
Release v2.0.1

### DIFF
--- a/alpine.dockerfile
+++ b/alpine.dockerfile
@@ -145,9 +145,11 @@ RUN mkdir /shairport-libs \
 FROM docker.io/alpine:3.18 as base
 ARG S6_OVERLAY_VERSION=3.1.5.0
 RUN apk add --no-cache \
+    avahi \
+    dbus \
     fdupes
 # Copy all necessary libaries into one directory to avoid carring over duplicates
-# Removes all libaries that are installed already in the base image
+# Removes all libaries that will be installed in the final image
 COPY --from=librespot /librespot-libs/ /tmp-libs/
 COPY --from=snapcast /snapserver-libs/ /tmp-libs/
 COPY --from=shairport /shairport-libs/ /tmp-libs/

--- a/alpine.dockerfile
+++ b/alpine.dockerfile
@@ -52,7 +52,7 @@ ENV CARGO_REGISTRIES_CRATES_IO_PROTOCOL="sparse"
 ENV CARGO_INCREMENTAL=0
 RUN git clone https://github.com/librespot-org/librespot \
    && cd librespot \
-   && git checkout 31d18f7e30b1e680bc8c56c0f5144ccb6f9f6aab
+   && git checkout c964102a349589d644baef5f43a566d6d1e151f1
 WORKDIR /librespot
 RUN cargo build --release --no-default-features --features with-dns-sd -j $(( $(nproc) -1 ))
 
@@ -99,7 +99,7 @@ FROM builder AS shairport
 ### NQPTP ###
 RUN git clone https://github.com/mikebrady/nqptp
 WORKDIR /nqptp
-RUN git checkout 5471c6c828e6dc19f24ff7106a042e4f5b3d604f \
+RUN git checkout 2afefb9d5e2d8ee09d2d9c77b831aedfb0a42ab1 \
     && autoreconf -i \
     && ./configure \
     && make -j $(( $(nproc) -1 ))
@@ -120,7 +120,7 @@ WORKDIR /
 ### SPS ###
 RUN git clone https://github.com/mikebrady/shairport-sync.git /shairport\
     && cd /shairport \
-    && git checkout 6e7f40a7f1535a2b6da64c27fe8d3875c0294c67
+    && git checkout a0e9c0ac34fd350d9179d6fc39c47e64bb07e875
 WORKDIR /shairport/build
 RUN autoreconf -i ../ \
     && ../configure --sysconfdir=/etc \

--- a/alpine.dockerfile
+++ b/alpine.dockerfile
@@ -166,6 +166,10 @@ RUN tar -C / -Jxpf /tmp/s6-overlay-noarch.tar.xz \
 
 ###### MAIN START ######
 FROM docker.io/alpine:3.18
+
+ENV S6_CMD_WAIT_FOR_SERVICES=1
+ENV S6_CMD_WAIT_FOR_SERVICES_MAXTIME=0
+
 RUN apk add --no-cache \
             avahi \
             dbus \

--- a/debian.dockerfile
+++ b/debian.dockerfile
@@ -64,7 +64,7 @@ ENV CARGO_INCREMENTAL=0
 ENV RUSTFLAGS="-C link-args=-fuse-ld=mold -C strip=symbols"
 RUN git clone https://github.com/librespot-org/librespot \
    && cd librespot \
-   && git checkout 31d18f7e30b1e680bc8c56c0f5144ccb6f9f6aab
+   && git checkout c964102a349589d644baef5f43a566d6d1e151f1
 WORKDIR /librespot
 RUN cargo build --release --no-default-features --features with-dns-sd -j $(( $(nproc) -1 ))
 
@@ -111,7 +111,7 @@ FROM builder AS shairport
 ### NQPTP ###
 RUN git clone https://github.com/mikebrady/nqptp
 WORKDIR /nqptp
-RUN git checkout 5471c6c828e6dc19f24ff7106a042e4f5b3d604f \
+RUN git checkout 2afefb9d5e2d8ee09d2d9c77b831aedfb0a42ab1 \
     && autoreconf -i \
     && ./configure \
     && make -j $(( $(nproc) -1 ))
@@ -133,7 +133,7 @@ RUN cp /usr/local/lib/libalac.* /usr/lib/
 ### SPS ###
 RUN git clone https://github.com/mikebrady/shairport-sync.git /shairport\
     && cd /shairport \
-    && git checkout 6e7f40a7f1535a2b6da64c27fe8d3875c0294c67
+    && git checkout a0e9c0ac34fd350d9179d6fc39c47e64bb07e875
 WORKDIR /shairport/build
 RUN autoreconf -i ../ \
     && ../configure --sysconfdir=/etc \

--- a/debian.dockerfile
+++ b/debian.dockerfile
@@ -183,6 +183,10 @@ RUN tar -C / -Jxpf /tmp/s6-overlay-noarch.tar.xz \
 
 ###### MAIN START ######
 FROM docker.io/debian:bookworm-slim
+
+ENV S6_CMD_WAIT_FOR_SERVICES=1
+ENV S6_CMD_WAIT_FOR_SERVICES_MAXTIME=0
+
 RUN apt-get update \
     && apt-get install --no-install-recommends -y \
         ca-certificates \

--- a/debian.dockerfile
+++ b/debian.dockerfile
@@ -159,11 +159,14 @@ FROM docker.io/debian:bookworm-slim as base
 ARG S6_OVERLAY_VERSION=3.1.5.0
 RUN apt-get update \
     && apt-get install --no-install-recommends -y \
+        ca-certificates \
+        avahi-daemon \
+        dbus\
         fdupes \
         xz-utils
 
 # Copy all necessary libaries into one directory to avoid carring over duplicates
-# Removes all libaries that are installed already in the base image
+# Removes all libaries that will be installed in the final image
 COPY --from=librespot /librespot-libs/ /tmp-libs/
 COPY --from=snapcast /snapserver-libs/ /tmp-libs/
 COPY --from=shairport /shairport-libs/ /tmp-libs/

--- a/s6-overlay/s6-rc.d/04-nqptp/dependencies
+++ b/s6-overlay/s6-rc.d/04-nqptp/dependencies
@@ -1,1 +1,1 @@
-03-avahi
+01-startup

--- a/s6-overlay/s6-rc.d/05-snapserver/dependencies
+++ b/s6-overlay/s6-rc.d/05-snapserver/dependencies
@@ -1,1 +1,2 @@
+03-avahi
 04-nqptp


### PR DESCRIPTION
Small release fix:

- `nqptp` does not depend on `avahI` on startup (but `snapserver` does)
- give the `s6` services as much time as needed to perform startup/readiness without generating a timeout on slow devices (see https://github.com/mikebrady/shairport-sync/issues/1677)
- don't copy libraries from the base to the final image by installing them on base before de-duping
- Update the components