### PR TITLE
v2.0.5

### DIFF
--- a/.github/workflows/publish_images.yml
+++ b/.github/workflows/publish_images.yml
@@ -5,6 +5,9 @@ on:
   release:
     types: [published]
   pull_request:
+  push:
+    branches:
+    - development
 
 env:
   REGISTRY_IMAGE: ghcr.io/${{ github.repository }}
@@ -33,13 +36,12 @@ jobs:
         with:
           images: |
             ${{ env.REGISTRY_IMAGE }}
-          flavor: latest=${{ startsWith(github.ref, 'refs/tags/') }}
           tags: |
             type=semver,pattern={{version}}
             type=semver,pattern={{major}}.{{minor}}
             type=semver,pattern={{major}}
-            type=sha, enable=${{ !startsWith(github.ref, 'refs/tags/') }}
-            type=edge
+            type=sha,enable=${{ github.event_name == 'workflow_dispatch' }}
+            type=ref,event=branch
 
       - name: Login to GitHub Container Registry
         if: github.event_name != 'pull_request'

--- a/README.md
+++ b/README.md
@@ -5,11 +5,8 @@ Alpine based Docker image for running the [snapserver part of snapcast](https://
 
 Idea adapted from [librespot-snapserver](https://github.com/djmaze/librespot-snapserver) and based on [shairport-sync docker image](https://github.com/mikebrady/shairport-sync/tree/master/docker)
 
- **Background:** As of 01/2023 the last release of *snapcast* is v0.26 from 12/2021 which is missing 118 commits compared to `develop`.
- Same for *librespot*, last release is v0.46 from 07/2022 which is missing 266 commits compared to `dev`.
- Therefore, everything is compiled from source.
-
- **Note:** Current last commit of the respective development branches for all repos are used to compile the lastest versions.
+ **Background:** When this project started, the last releases of *snapcast* and *librespot* where outdated compared to their respective `develop` branches.
+  Therefore, everything is compiled from source using the development branches for all repos.
 
  **Note** The coresponding Docker image for runinng `snapclient` can be found here: [https://github.com/yubiuser/snapclient-docker](https://github.com/yubiuser/snapclient-docker)
 
@@ -44,13 +41,10 @@ To build the image simply run
 
 `docker build -t librespot-shairport-snapserver:local -f ./alpine.dockerfile .`
 
-
 ## Notes
 
-- Based on Alpine 3:18; final image size is ~116MB
+- Based on Alpine 3:19; final image size is ~116MB
 - All `(c)make` calles use the option `-j $(( $(nproc) -1 ))` to leave one CPU for normal operation
-- Compiling `snapserver`
-  - Logging of information of the `airplay-stream` metadata handler has been modified from `info` to `debug` to reduce logspam
 - `s6-overlay` is used as `init` system (same as the [shairport-sync docker image](https://github.com/mikebrady/shairport-sync/tree/master/docker)). This is necessary, because *shairport-sync* needs a companion application called [NQPTP](https://github.com/mikebrady/nqptp) which needs to be started from `root` to run as deamon.
   - `s6-rc` with configured dependencies is used to start all services. `snapserver` should start as last
   - `s6-notifyoncheck` is used to check readiness of the started services `dbus` and `avahi`. The actual check is performed by sending `dbus`messages and analyzing the reply.

--- a/alpine.dockerfile
+++ b/alpine.dockerfile
@@ -142,7 +142,7 @@ RUN mkdir /shairport-libs \
 
 ###### BASE START ######
 FROM docker.io/alpine:3.18 as base
-ARG S6_OVERLAY_VERSION=3.1.5.0
+ARG S6_OVERLAY_VERSION=3.1.6.0
 RUN apk add --no-cache \
     avahi \
     dbus \

--- a/alpine.dockerfile
+++ b/alpine.dockerfile
@@ -67,7 +67,7 @@ FROM builder AS snapcast
 ### SNAPSERVER ###
 RUN git clone https://github.com/badaix/snapcast.git /snapcast \
     && cd snapcast \
-    && git checkout abe6dea35ad80f71d1046006aa19170752d95e35 \
+    && git checkout 61ff3032b97b9fe5fc169b4a80c76040266a4b93 \
     && sed -i 's/LOG(INFO, LOG_TAG) << "Waiting for metadata/LOG(DEBUG, LOG_TAG) << "Waiting for metadata/' "./server/streamreader/airplay_stream.cpp"
 WORKDIR /snapcast
 RUN cmake -S . -B build -DBUILD_CLIENT=OFF \
@@ -83,7 +83,7 @@ RUN mkdir /snapserver-libs \
 ### SNAPWEB ###
 RUN git clone https://github.com/badaix/snapweb.git
 WORKDIR /snapweb
-RUN git checkout 20404d7924392250587006f535fb59c9166bf137
+RUN git checkout 40590affd29ffdcf74768e2b06d67c2241676abb
 ENV GENERATE_SOURCEMAP="false"
 RUN npm install -g npm@latest \
     && npm ci \
@@ -98,7 +98,7 @@ FROM builder AS shairport
 ### NQPTP ###
 RUN git clone https://github.com/mikebrady/nqptp
 WORKDIR /nqptp
-RUN git checkout 3b761738e0e5995b06de9bacbcf9bb875949f266 \
+RUN git checkout 5fb99599d87f09a38497c698173b46ac901ec7ce \
     && autoreconf -i \
     && ./configure \
     && make -j $(( $(nproc) -1 ))
@@ -119,7 +119,7 @@ WORKDIR /
 ### SPS ###
 RUN git clone https://github.com/mikebrady/shairport-sync.git /shairport\
     && cd /shairport \
-    && git checkout 53d922e4d4651815fcbd51fe530d2b61466989c5
+    && git checkout 23946b53b3bf903207fbc539577d865a2d241f01
 WORKDIR /shairport/build
 RUN autoreconf -i ../ \
     && ../configure --sysconfdir=/etc \

--- a/alpine.dockerfile
+++ b/alpine.dockerfile
@@ -55,7 +55,7 @@ ENV CARGO_REGISTRIES_CRATES_IO_PROTOCOL="sparse"
 ENV CARGO_INCREMENTAL=0
 RUN git clone https://github.com/librespot-org/librespot \
    && cd librespot \
-   && git checkout 054074c920d5c6acf0210faa3cd849dc4e065828
+   && git checkout 886617e41c2177d0cb184cb761aa64acc8695a88
 WORKDIR /librespot
 RUN cargo build --release --no-default-features --features with-dns-sd -j $(( $(nproc) -1 ))
 
@@ -70,7 +70,7 @@ FROM builder AS snapcast
 ### SNAPSERVER ###
 RUN git clone https://github.com/badaix/snapcast.git /snapcast \
     && cd snapcast \
-    && git checkout 39ee4cc3a5dffc57221015dbc291fb429ac82835 \
+    && git checkout 2c575370526fa58a224bd82bf2ee614023378f37 \
     && sed -i 's/LOG(INFO, LOG_TAG) << "Waiting for metadata/LOG(DEBUG, LOG_TAG) << "Waiting for metadata/' "./server/streamreader/airplay_stream.cpp"
 WORKDIR /snapcast
 RUN cmake -S . -B build -DBUILD_CLIENT=OFF \
@@ -122,7 +122,7 @@ WORKDIR /
 ### SPS ###
 RUN git clone https://github.com/mikebrady/shairport-sync.git /shairport\
     && cd /shairport \
-    && git checkout 5f9a88fb74604fad410b9fbecd3be3f85b51c834
+    && git checkout e36ec5c45d872cd1bdc59a24b805560b5e7029aa
 WORKDIR /shairport/build
 RUN autoreconf -i ../ \
     && ../configure --sysconfdir=/etc \

--- a/alpine.dockerfile
+++ b/alpine.dockerfile
@@ -70,8 +70,7 @@ FROM builder AS snapcast
 ### SNAPSERVER ###
 RUN git clone https://github.com/badaix/snapcast.git /snapcast \
     && cd snapcast \
-    && git checkout 86cd4b2b63e750a72e0dfe6a46d47caf01426c8d \
-    && sed -i 's/LOG(INFO, LOG_TAG) << "Waiting for metadata/LOG(DEBUG, LOG_TAG) << "Waiting for metadata/' "./server/streamreader/airplay_stream.cpp"
+    && git checkout b6c11930127d1ea6efe48de93b4add8ffe1fd0e9
 WORKDIR /snapcast
 RUN cmake -S . -B build -DBUILD_CLIENT=OFF \
     && cmake --build build -j $(( $(nproc) -1 )) --verbose \
@@ -86,8 +85,7 @@ RUN mkdir /snapserver-libs \
 ### SNAPWEB ###
 RUN git clone https://github.com/badaix/snapweb.git
 WORKDIR /snapweb
-# vite branch
-RUN git checkout c7812614e619b6490f53506ab4be7de8637f49a9
+RUN git checkout bdfa68a9e6457632604edb7cc7f5df0c4d23dd08
 ENV GENERATE_SOURCEMAP="false"
 RUN npm install -g npm@latest \
     && npm ci \

--- a/alpine.dockerfile
+++ b/alpine.dockerfile
@@ -67,7 +67,7 @@ FROM builder AS snapcast
 ### SNAPSERVER ###
 RUN git clone https://github.com/badaix/snapcast.git /snapcast \
     && cd snapcast \
-    && git checkout 61ff3032b97b9fe5fc169b4a80c76040266a4b93 \
+    && git checkout 39ee4cc3a5dffc57221015dbc291fb429ac82835 \
     && sed -i 's/LOG(INFO, LOG_TAG) << "Waiting for metadata/LOG(DEBUG, LOG_TAG) << "Waiting for metadata/' "./server/streamreader/airplay_stream.cpp"
 WORKDIR /snapcast
 RUN cmake -S . -B build -DBUILD_CLIENT=OFF \
@@ -119,7 +119,7 @@ WORKDIR /
 ### SPS ###
 RUN git clone https://github.com/mikebrady/shairport-sync.git /shairport\
     && cd /shairport \
-    && git checkout 23946b53b3bf903207fbc539577d865a2d241f01
+    && git checkout 5f9a88fb74604fad410b9fbecd3be3f85b51c834
 WORKDIR /shairport/build
 RUN autoreconf -i ../ \
     && ../configure --sysconfdir=/etc \

--- a/alpine.dockerfile
+++ b/alpine.dockerfile
@@ -142,7 +142,7 @@ RUN mkdir /shairport-libs \
 
 ###### BASE START ######
 FROM docker.io/alpine:3.18 as base
-ARG S6_OVERLAY_VERSION=3.1.6.0
+ARG S6_OVERLAY_VERSION=3.1.6.2
 RUN apk add --no-cache \
     avahi \
     dbus \

--- a/alpine.dockerfile
+++ b/alpine.dockerfile
@@ -55,7 +55,7 @@ ENV CARGO_REGISTRIES_CRATES_IO_PROTOCOL="sparse"
 ENV CARGO_INCREMENTAL=0
 RUN git clone https://github.com/librespot-org/librespot \
    && cd librespot \
-   && git checkout f5a46c61d2a1a96120516cee26cd7e4b95c20f50
+   && git checkout 4d35c5ffe222c839d1532d8afac78fe4c37043b3
 WORKDIR /librespot
 RUN cargo build --release --no-default-features --features with-dns-sd -j $(( $(nproc) -1 ))
 
@@ -70,7 +70,7 @@ FROM builder AS snapcast
 ### SNAPSERVER ###
 RUN git clone https://github.com/badaix/snapcast.git /snapcast \
     && cd snapcast \
-    && git checkout 0e74570dcc485b293fe09d9326529284f3b9e3a8 \
+    && git checkout 86cd4b2b63e750a72e0dfe6a46d47caf01426c8d \
     && sed -i 's/LOG(INFO, LOG_TAG) << "Waiting for metadata/LOG(DEBUG, LOG_TAG) << "Waiting for metadata/' "./server/streamreader/airplay_stream.cpp"
 WORKDIR /snapcast
 RUN cmake -S . -B build -DBUILD_CLIENT=OFF \
@@ -86,7 +86,8 @@ RUN mkdir /snapserver-libs \
 ### SNAPWEB ###
 RUN git clone https://github.com/badaix/snapweb.git
 WORKDIR /snapweb
-RUN git checkout ad2f6d4bed51ac3972193d1b4dde640c5428b1f7
+# vite branch
+RUN git checkout c7812614e619b6490f53506ab4be7de8637f49a9
 ENV GENERATE_SOURCEMAP="false"
 RUN npm install -g npm@latest \
     && npm ci \
@@ -101,7 +102,7 @@ FROM builder AS shairport
 ### NQPTP ###
 RUN git clone https://github.com/mikebrady/nqptp
 WORKDIR /nqptp
-RUN git checkout 5fb99599d87f09a38497c698173b46ac901ec7ce \
+RUN git checkout 6777e562b4c0cec54b8f419b85db48521258c605 \
     && autoreconf -i \
     && ./configure \
     && make -j $(( $(nproc) -1 ))
@@ -122,7 +123,7 @@ WORKDIR /
 ### SPS ###
 RUN git clone https://github.com/mikebrady/shairport-sync.git /shairport\
     && cd /shairport \
-    && git checkout 00a47584049789286e4ced0d95745066e4b0cb77
+    && git checkout 9862793256cf897330b4997fee66f488cbdb77cf
 WORKDIR /shairport/build
 RUN autoreconf -i ../ \
     && ../configure --sysconfdir=/etc \
@@ -187,7 +188,7 @@ COPY --from=base /tmp-libs/ /usr/lib/
 # Copy all necessary files from the builders
 COPY --from=librespot /librespot/target/release/librespot /usr/local/bin/
 COPY --from=snapcast /snapcast/bin/snapserver /usr/local/bin/
-COPY --from=snapcast /snapweb/build /usr/share/snapserver/snapweb
+COPY --from=snapcast /snapweb/dist /usr/share/snapserver/snapweb
 COPY --from=shairport /shairport/build/shairport-sync /usr/local/bin/
 COPY --from=shairport /nqptp/nqptp /usr/local/bin/
 

--- a/alpine.dockerfile
+++ b/alpine.dockerfile
@@ -55,7 +55,7 @@ ENV CARGO_REGISTRIES_CRATES_IO_PROTOCOL="sparse"
 ENV CARGO_INCREMENTAL=0
 RUN git clone https://github.com/librespot-org/librespot \
    && cd librespot \
-   && git checkout 886617e41c2177d0cb184cb761aa64acc8695a88
+   && git checkout f5a46c61d2a1a96120516cee26cd7e4b95c20f50
 WORKDIR /librespot
 RUN cargo build --release --no-default-features --features with-dns-sd -j $(( $(nproc) -1 ))
 
@@ -70,7 +70,7 @@ FROM builder AS snapcast
 ### SNAPSERVER ###
 RUN git clone https://github.com/badaix/snapcast.git /snapcast \
     && cd snapcast \
-    && git checkout 2c575370526fa58a224bd82bf2ee614023378f37 \
+    && git checkout 0e74570dcc485b293fe09d9326529284f3b9e3a8 \
     && sed -i 's/LOG(INFO, LOG_TAG) << "Waiting for metadata/LOG(DEBUG, LOG_TAG) << "Waiting for metadata/' "./server/streamreader/airplay_stream.cpp"
 WORKDIR /snapcast
 RUN cmake -S . -B build -DBUILD_CLIENT=OFF \
@@ -86,7 +86,7 @@ RUN mkdir /snapserver-libs \
 ### SNAPWEB ###
 RUN git clone https://github.com/badaix/snapweb.git
 WORKDIR /snapweb
-RUN git checkout 40590affd29ffdcf74768e2b06d67c2241676abb
+RUN git checkout ad2f6d4bed51ac3972193d1b4dde640c5428b1f7
 ENV GENERATE_SOURCEMAP="false"
 RUN npm install -g npm@latest \
     && npm ci \
@@ -122,7 +122,7 @@ WORKDIR /
 ### SPS ###
 RUN git clone https://github.com/mikebrady/shairport-sync.git /shairport\
     && cd /shairport \
-    && git checkout e36ec5c45d872cd1bdc59a24b805560b5e7029aa
+    && git checkout 00a47584049789286e4ced0d95745066e4b0cb77
 WORKDIR /shairport/build
 RUN autoreconf -i ../ \
     && ../configure --sysconfdir=/etc \

--- a/alpine.dockerfile
+++ b/alpine.dockerfile
@@ -98,7 +98,7 @@ FROM builder AS shairport
 ### NQPTP ###
 RUN git clone https://github.com/mikebrady/nqptp
 WORKDIR /nqptp
-RUN git checkout 5e9a1e1e26b417c85e8c46c62a4ac71f22f2309b \
+RUN git checkout 3b761738e0e5995b06de9bacbcf9bb875949f266 \
     && autoreconf -i \
     && ./configure \
     && make -j $(( $(nproc) -1 ))
@@ -119,7 +119,7 @@ WORKDIR /
 ### SPS ###
 RUN git clone https://github.com/mikebrady/shairport-sync.git /shairport\
     && cd /shairport \
-    && git checkout 73af29c8238a506b2f349f6702c6e33ccaeb0e60
+    && git checkout 53d922e4d4651815fcbd51fe530d2b61466989c5
 WORKDIR /shairport/build
 RUN autoreconf -i ../ \
     && ../configure --sysconfdir=/etc \

--- a/alpine.dockerfile
+++ b/alpine.dockerfile
@@ -55,7 +55,7 @@ ENV CARGO_REGISTRIES_CRATES_IO_PROTOCOL="sparse"
 ENV CARGO_INCREMENTAL=0
 RUN git clone https://github.com/librespot-org/librespot \
    && cd librespot \
-   && git checkout 4d35c5ffe222c839d1532d8afac78fe4c37043b3
+   && git checkout a6065d6bed3d40dabb9613fe773124e5b8380ecc
 WORKDIR /librespot
 RUN cargo build --release --no-default-features --features with-dns-sd -j $(( $(nproc) -1 ))
 
@@ -70,7 +70,7 @@ FROM builder AS snapcast
 ### SNAPSERVER ###
 RUN git clone https://github.com/badaix/snapcast.git /snapcast \
     && cd snapcast \
-    && git checkout b6c11930127d1ea6efe48de93b4add8ffe1fd0e9
+    && git checkout 245921009e015ed3cd1f635aed51b63cae7c1600
 WORKDIR /snapcast
 RUN cmake -S . -B build -DBUILD_CLIENT=OFF \
     && cmake --build build -j $(( $(nproc) -1 )) --verbose \
@@ -85,7 +85,7 @@ RUN mkdir /snapserver-libs \
 ### SNAPWEB ###
 RUN git clone https://github.com/badaix/snapweb.git
 WORKDIR /snapweb
-RUN git checkout bdfa68a9e6457632604edb7cc7f5df0c4d23dd08
+RUN git checkout eb23e03e9f7dc735f37b8e413fb803f1265938e2
 ENV GENERATE_SOURCEMAP="false"
 RUN npm install -g npm@latest \
     && npm ci \
@@ -100,7 +100,7 @@ FROM builder AS shairport
 ### NQPTP ###
 RUN git clone https://github.com/mikebrady/nqptp
 WORKDIR /nqptp
-RUN git checkout 6777e562b4c0cec54b8f419b85db48521258c605 \
+RUN git checkout 59ccf05444f88f7ceaa86c00f9bb64cc06c26cb4 \
     && autoreconf -i \
     && ./configure \
     && make -j $(( $(nproc) -1 ))
@@ -110,7 +110,7 @@ WORKDIR /
 ### ALAC ###
 RUN git clone https://github.com/mikebrady/alac
 WORKDIR /alac
-RUN git checkout 96dd59d17b776a7dc94ed9b2c2b4a37177feb3c4 \
+RUN git checkout 34b327964c2287a49eb79b88b0ace278835ae95f \
     && autoreconf -i \
     && ./configure \
     && make -j $(( $(nproc) -1 )) \
@@ -121,7 +121,7 @@ WORKDIR /
 ### SPS ###
 RUN git clone https://github.com/mikebrady/shairport-sync.git /shairport\
     && cd /shairport \
-    && git checkout 9862793256cf897330b4997fee66f488cbdb77cf
+    && git checkout 5d24d847683aad97eeb4efe6448ac726feb50143
 WORKDIR /shairport/build
 RUN autoreconf -i ../ \
     && ../configure --sysconfdir=/etc \

--- a/debian.dockerfile
+++ b/debian.dockerfile
@@ -110,7 +110,7 @@ FROM builder AS shairport
 ### NQPTP ###
 RUN git clone https://github.com/mikebrady/nqptp
 WORKDIR /nqptp
-RUN git checkout 5e9a1e1e26b417c85e8c46c62a4ac71f22f2309b \
+RUN git checkout 3b761738e0e5995b06de9bacbcf9bb875949f266 \
     && autoreconf -i \
     && ./configure \
     && make -j $(( $(nproc) -1 ))
@@ -132,7 +132,7 @@ RUN cp /usr/local/lib/libalac.* /usr/lib/
 ### SPS ###
 RUN git clone https://github.com/mikebrady/shairport-sync.git /shairport\
     && cd /shairport \
-    && git checkout 73af29c8238a506b2f349f6702c6e33ccaeb0e60
+    && git checkout 53d922e4d4651815fcbd51fe530d2b61466989c5
 WORKDIR /shairport/build
 RUN autoreconf -i ../ \
     && ../configure --sysconfdir=/etc \

--- a/debian.dockerfile
+++ b/debian.dockerfile
@@ -64,7 +64,7 @@ ENV CARGO_INCREMENTAL=0
 ENV RUSTFLAGS="-C link-args=-fuse-ld=mold -C strip=symbols"
 RUN git clone https://github.com/librespot-org/librespot \
    && cd librespot \
-   && git checkout 886617e41c2177d0cb184cb761aa64acc8695a88
+   && git checkout f5a46c61d2a1a96120516cee26cd7e4b95c20f50
 WORKDIR /librespot
 RUN cargo build --release --no-default-features --features with-dns-sd -j $(( $(nproc) -1 ))
 
@@ -79,7 +79,7 @@ FROM builder AS snapcast
 ### SNAPSERVER ###
 RUN git clone https://github.com/badaix/snapcast.git /snapcast \
     && cd snapcast \
-    && git checkout 2c575370526fa58a224bd82bf2ee614023378f37 \
+    && git checkout 0e74570dcc485b293fe09d9326529284f3b9e3a8 \
     && sed -i 's/LOG(INFO, LOG_TAG) << "Waiting for metadata/LOG(DEBUG, LOG_TAG) << "Waiting for metadata/' "./server/streamreader/airplay_stream.cpp"
 WORKDIR /snapcast
 RUN cmake -S . -B build -DBUILD_CLIENT=OFF \
@@ -95,7 +95,7 @@ RUN mkdir /snapserver-libs \
 ### SNAPWEB ###
 RUN git clone https://github.com/badaix/snapweb.git
 WORKDIR /snapweb
-RUN git checkout 40590affd29ffdcf74768e2b06d67c2241676abb
+RUN git checkout ad2f6d4bed51ac3972193d1b4dde640c5428b1f7
 ENV GENERATE_SOURCEMAP="false"
 RUN npm install -g npm@latest \
     && npm ci \
@@ -132,7 +132,7 @@ RUN cp /usr/local/lib/libalac.* /usr/lib/
 ### SPS ###
 RUN git clone https://github.com/mikebrady/shairport-sync.git /shairport\
     && cd /shairport \
-    && git checkout e36ec5c45d872cd1bdc59a24b805560b5e7029aa
+    && git checkout 00a47584049789286e4ced0d95745066e4b0cb77
 WORKDIR /shairport/build
 RUN autoreconf -i ../ \
     && ../configure --sysconfdir=/etc \

--- a/debian.dockerfile
+++ b/debian.dockerfile
@@ -155,7 +155,7 @@ RUN mkdir /shairport-libs \
 
 ###### BASE START ######
 FROM docker.io/debian:bookworm-slim as base
-ARG S6_OVERLAY_VERSION=3.1.5.0
+ARG S6_OVERLAY_VERSION=3.1.6.0
 RUN apt-get update \
     && apt-get install --no-install-recommends -y \
         ca-certificates \

--- a/debian.dockerfile
+++ b/debian.dockerfile
@@ -79,7 +79,7 @@ FROM builder AS snapcast
 ### SNAPSERVER ###
 RUN git clone https://github.com/badaix/snapcast.git /snapcast \
     && cd snapcast \
-    && git checkout 61ff3032b97b9fe5fc169b4a80c76040266a4b93 \
+    && git checkout 39ee4cc3a5dffc57221015dbc291fb429ac82835 \
     && sed -i 's/LOG(INFO, LOG_TAG) << "Waiting for metadata/LOG(DEBUG, LOG_TAG) << "Waiting for metadata/' "./server/streamreader/airplay_stream.cpp"
 WORKDIR /snapcast
 RUN cmake -S . -B build -DBUILD_CLIENT=OFF \
@@ -132,7 +132,7 @@ RUN cp /usr/local/lib/libalac.* /usr/lib/
 ### SPS ###
 RUN git clone https://github.com/mikebrady/shairport-sync.git /shairport\
     && cd /shairport \
-    && git checkout 23946b53b3bf903207fbc539577d865a2d241f01
+    && git checkout 5f9a88fb74604fad410b9fbecd3be3f85b51c834
 WORKDIR /shairport/build
 RUN autoreconf -i ../ \
     && ../configure --sysconfdir=/etc \

--- a/debian.dockerfile
+++ b/debian.dockerfile
@@ -155,7 +155,7 @@ RUN mkdir /shairport-libs \
 
 ###### BASE START ######
 FROM docker.io/debian:bookworm-slim as base
-ARG S6_OVERLAY_VERSION=3.1.6.0
+ARG S6_OVERLAY_VERSION=3.1.6.2
 RUN apt-get update \
     && apt-get install --no-install-recommends -y \
         ca-certificates \

--- a/debian.dockerfile
+++ b/debian.dockerfile
@@ -79,7 +79,7 @@ FROM builder AS snapcast
 ### SNAPSERVER ###
 RUN git clone https://github.com/badaix/snapcast.git /snapcast \
     && cd snapcast \
-    && git checkout abe6dea35ad80f71d1046006aa19170752d95e35 \
+    && git checkout 61ff3032b97b9fe5fc169b4a80c76040266a4b93 \
     && sed -i 's/LOG(INFO, LOG_TAG) << "Waiting for metadata/LOG(DEBUG, LOG_TAG) << "Waiting for metadata/' "./server/streamreader/airplay_stream.cpp"
 WORKDIR /snapcast
 RUN cmake -S . -B build -DBUILD_CLIENT=OFF \
@@ -95,7 +95,7 @@ RUN mkdir /snapserver-libs \
 ### SNAPWEB ###
 RUN git clone https://github.com/badaix/snapweb.git
 WORKDIR /snapweb
-RUN git checkout 20404d7924392250587006f535fb59c9166bf137
+RUN git checkout 40590affd29ffdcf74768e2b06d67c2241676abb
 ENV GENERATE_SOURCEMAP="false"
 RUN npm install -g npm@latest \
     && npm ci \
@@ -110,7 +110,7 @@ FROM builder AS shairport
 ### NQPTP ###
 RUN git clone https://github.com/mikebrady/nqptp
 WORKDIR /nqptp
-RUN git checkout 3b761738e0e5995b06de9bacbcf9bb875949f266 \
+RUN git checkout 5fb99599d87f09a38497c698173b46ac901ec7ce \
     && autoreconf -i \
     && ./configure \
     && make -j $(( $(nproc) -1 ))
@@ -132,7 +132,7 @@ RUN cp /usr/local/lib/libalac.* /usr/lib/
 ### SPS ###
 RUN git clone https://github.com/mikebrady/shairport-sync.git /shairport\
     && cd /shairport \
-    && git checkout 53d922e4d4651815fcbd51fe530d2b61466989c5
+    && git checkout 23946b53b3bf903207fbc539577d865a2d241f01
 WORKDIR /shairport/build
 RUN autoreconf -i ../ \
     && ../configure --sysconfdir=/etc \

--- a/debian.dockerfile
+++ b/debian.dockerfile
@@ -64,7 +64,7 @@ ENV CARGO_INCREMENTAL=0
 ENV RUSTFLAGS="-C link-args=-fuse-ld=mold -C strip=symbols"
 RUN git clone https://github.com/librespot-org/librespot \
    && cd librespot \
-   && git checkout f5a46c61d2a1a96120516cee26cd7e4b95c20f50
+   && git checkout 4d35c5ffe222c839d1532d8afac78fe4c37043b3
 WORKDIR /librespot
 RUN cargo build --release --no-default-features --features with-dns-sd -j $(( $(nproc) -1 ))
 
@@ -79,7 +79,7 @@ FROM builder AS snapcast
 ### SNAPSERVER ###
 RUN git clone https://github.com/badaix/snapcast.git /snapcast \
     && cd snapcast \
-    && git checkout 0e74570dcc485b293fe09d9326529284f3b9e3a8 \
+    && git checkout 86cd4b2b63e750a72e0dfe6a46d47caf01426c8d \
     && sed -i 's/LOG(INFO, LOG_TAG) << "Waiting for metadata/LOG(DEBUG, LOG_TAG) << "Waiting for metadata/' "./server/streamreader/airplay_stream.cpp"
 WORKDIR /snapcast
 RUN cmake -S . -B build -DBUILD_CLIENT=OFF \
@@ -95,7 +95,8 @@ RUN mkdir /snapserver-libs \
 ### SNAPWEB ###
 RUN git clone https://github.com/badaix/snapweb.git
 WORKDIR /snapweb
-RUN git checkout ad2f6d4bed51ac3972193d1b4dde640c5428b1f7
+# vite branch
+RUN git checkout c7812614e619b6490f53506ab4be7de8637f49a9
 ENV GENERATE_SOURCEMAP="false"
 RUN npm install -g npm@latest \
     && npm ci \
@@ -110,7 +111,7 @@ FROM builder AS shairport
 ### NQPTP ###
 RUN git clone https://github.com/mikebrady/nqptp
 WORKDIR /nqptp
-RUN git checkout 5fb99599d87f09a38497c698173b46ac901ec7ce \
+RUN git checkout 6777e562b4c0cec54b8f419b85db48521258c605 \
     && autoreconf -i \
     && ./configure \
     && make -j $(( $(nproc) -1 ))
@@ -132,7 +133,7 @@ RUN cp /usr/local/lib/libalac.* /usr/lib/
 ### SPS ###
 RUN git clone https://github.com/mikebrady/shairport-sync.git /shairport\
     && cd /shairport \
-    && git checkout 00a47584049789286e4ced0d95745066e4b0cb77
+    && git checkout 9862793256cf897330b4997fee66f488cbdb77cf
 WORKDIR /shairport/build
 RUN autoreconf -i ../ \
     && ../configure --sysconfdir=/etc \
@@ -204,7 +205,7 @@ COPY --from=base /tmp-libs/ /lib/x86_64-linux-gnu/
 # Copy all necessary files from the builders
 COPY --from=librespot /librespot/target/release/librespot /usr/local/bin/
 COPY --from=snapcast /snapcast/bin/snapserver /usr/local/bin/
-COPY --from=snapcast /snapweb/build /usr/share/snapserver/snapweb
+COPY --from=snapcast /snapweb/dist /usr/share/snapserver/snapweb
 COPY --from=shairport /shairport/build/shairport-sync /usr/local/bin/
 COPY --from=shairport /nqptp/nqptp /usr/local/bin/
 

--- a/debian.dockerfile
+++ b/debian.dockerfile
@@ -64,7 +64,7 @@ ENV CARGO_INCREMENTAL=0
 ENV RUSTFLAGS="-C link-args=-fuse-ld=mold -C strip=symbols"
 RUN git clone https://github.com/librespot-org/librespot \
    && cd librespot \
-   && git checkout 054074c920d5c6acf0210faa3cd849dc4e065828
+   && git checkout 886617e41c2177d0cb184cb761aa64acc8695a88
 WORKDIR /librespot
 RUN cargo build --release --no-default-features --features with-dns-sd -j $(( $(nproc) -1 ))
 
@@ -79,7 +79,7 @@ FROM builder AS snapcast
 ### SNAPSERVER ###
 RUN git clone https://github.com/badaix/snapcast.git /snapcast \
     && cd snapcast \
-    && git checkout 39ee4cc3a5dffc57221015dbc291fb429ac82835 \
+    && git checkout 2c575370526fa58a224bd82bf2ee614023378f37 \
     && sed -i 's/LOG(INFO, LOG_TAG) << "Waiting for metadata/LOG(DEBUG, LOG_TAG) << "Waiting for metadata/' "./server/streamreader/airplay_stream.cpp"
 WORKDIR /snapcast
 RUN cmake -S . -B build -DBUILD_CLIENT=OFF \
@@ -132,7 +132,7 @@ RUN cp /usr/local/lib/libalac.* /usr/lib/
 ### SPS ###
 RUN git clone https://github.com/mikebrady/shairport-sync.git /shairport\
     && cd /shairport \
-    && git checkout 5f9a88fb74604fad410b9fbecd3be3f85b51c834
+    && git checkout e36ec5c45d872cd1bdc59a24b805560b5e7029aa
 WORKDIR /shairport/build
 RUN autoreconf -i ../ \
     && ../configure --sysconfdir=/etc \

--- a/debian.dockerfile
+++ b/debian.dockerfile
@@ -79,8 +79,7 @@ FROM builder AS snapcast
 ### SNAPSERVER ###
 RUN git clone https://github.com/badaix/snapcast.git /snapcast \
     && cd snapcast \
-    && git checkout 86cd4b2b63e750a72e0dfe6a46d47caf01426c8d \
-    && sed -i 's/LOG(INFO, LOG_TAG) << "Waiting for metadata/LOG(DEBUG, LOG_TAG) << "Waiting for metadata/' "./server/streamreader/airplay_stream.cpp"
+    && git checkout 86cd4b2b63e750a72e0dfe6a46d47caf01426c8d
 WORKDIR /snapcast
 RUN cmake -S . -B build -DBUILD_CLIENT=OFF \
     && cmake --build build -j $(( $(nproc) -1 )) --verbose \
@@ -95,8 +94,7 @@ RUN mkdir /snapserver-libs \
 ### SNAPWEB ###
 RUN git clone https://github.com/badaix/snapweb.git
 WORKDIR /snapweb
-# vite branch
-RUN git checkout c7812614e619b6490f53506ab4be7de8637f49a9
+RUN git checkout bdfa68a9e6457632604edb7cc7f5df0c4d23dd08
 ENV GENERATE_SOURCEMAP="false"
 RUN npm install -g npm@latest \
     && npm ci \

--- a/debian.dockerfile
+++ b/debian.dockerfile
@@ -64,7 +64,7 @@ ENV CARGO_INCREMENTAL=0
 ENV RUSTFLAGS="-C link-args=-fuse-ld=mold -C strip=symbols"
 RUN git clone https://github.com/librespot-org/librespot \
    && cd librespot \
-   && git checkout 4d35c5ffe222c839d1532d8afac78fe4c37043b3
+   && git checkout a6065d6bed3d40dabb9613fe773124e5b8380ecc
 WORKDIR /librespot
 RUN cargo build --release --no-default-features --features with-dns-sd -j $(( $(nproc) -1 ))
 
@@ -79,7 +79,7 @@ FROM builder AS snapcast
 ### SNAPSERVER ###
 RUN git clone https://github.com/badaix/snapcast.git /snapcast \
     && cd snapcast \
-    && git checkout 86cd4b2b63e750a72e0dfe6a46d47caf01426c8d
+    && git checkout 245921009e015ed3cd1f635aed51b63cae7c1600
 WORKDIR /snapcast
 RUN cmake -S . -B build -DBUILD_CLIENT=OFF \
     && cmake --build build -j $(( $(nproc) -1 )) --verbose \
@@ -94,7 +94,7 @@ RUN mkdir /snapserver-libs \
 ### SNAPWEB ###
 RUN git clone https://github.com/badaix/snapweb.git
 WORKDIR /snapweb
-RUN git checkout bdfa68a9e6457632604edb7cc7f5df0c4d23dd08
+RUN git checkout eb23e03e9f7dc735f37b8e413fb803f1265938e2
 ENV GENERATE_SOURCEMAP="false"
 RUN npm install -g npm@latest \
     && npm ci \
@@ -109,7 +109,7 @@ FROM builder AS shairport
 ### NQPTP ###
 RUN git clone https://github.com/mikebrady/nqptp
 WORKDIR /nqptp
-RUN git checkout 6777e562b4c0cec54b8f419b85db48521258c605 \
+RUN git checkout 59ccf05444f88f7ceaa86c00f9bb64cc06c26cb4 \
     && autoreconf -i \
     && ./configure \
     && make -j $(( $(nproc) -1 ))
@@ -119,7 +119,7 @@ WORKDIR /
 ### ALAC ###
 RUN git clone https://github.com/mikebrady/alac
 WORKDIR /alac
-RUN git checkout 96dd59d17b776a7dc94ed9b2c2b4a37177feb3c4 \
+RUN git checkout 34b327964c2287a49eb79b88b0ace278835ae95f \
     && autoreconf -i \
     && ./configure \
     && make -j $(( $(nproc) -1 )) \
@@ -131,7 +131,7 @@ RUN cp /usr/local/lib/libalac.* /usr/lib/
 ### SPS ###
 RUN git clone https://github.com/mikebrady/shairport-sync.git /shairport\
     && cd /shairport \
-    && git checkout 9862793256cf897330b4997fee66f488cbdb77cf
+    && git checkout 5d24d847683aad97eeb4efe6448ac726feb50143
 WORKDIR /shairport/build
 RUN autoreconf -i ../ \
     && ../configure --sysconfdir=/etc \


### PR DESCRIPTION
- Publish `development` tag image
- Remove  monkey patch to lower log level for retrieas it fixed upstreams by https://github.com/badaix/snapcast/commit/fcac07b07aabe352c5109a5a5b83589a732202a6

Updates 
- `librespot` to `8f9bec21d7a0d1e095039c1ff9ecd7c532d9e74e`
- `shairport-sync` to `28ae1dae85ac58f78602f9ed0597247851d15473`
- `nqptp` to `b8384c4a53632bab028c451a625ef51a1e767f29`
- `alac` to `34b327964c2287a49eb79b88b0ace278835ae95f`
- `snapcast` to `a31238a2fbf63c55c57dded9bfbe82e868f48cef`
- `snapweb` to `215da28e21e03e983b79f8232434c1ed1da9ef62`
- `s6_overlay` to `3.2.0.0.`
- alpine base to `3.20`
plus some workflow dependencies