### PR TITLE
v2.0.6

### DIFF
--- a/.github/workflows/publish_images.yml
+++ b/.github/workflows/publish_images.yml
@@ -5,6 +5,9 @@ on:
   release:
     types: [published]
   pull_request:
+  push:
+    branches:
+    - development
 
 env:
   REGISTRY_IMAGE: ghcr.io/${{ github.repository }}
@@ -33,13 +36,12 @@ jobs:
         with:
           images: |
             ${{ env.REGISTRY_IMAGE }}
-          flavor: latest=${{ startsWith(github.ref, 'refs/tags/') }}
           tags: |
             type=semver,pattern={{version}}
             type=semver,pattern={{major}}.{{minor}}
             type=semver,pattern={{major}}
-            type=sha, enable=${{ !startsWith(github.ref, 'refs/tags/') }}
-            type=edge
+            type=sha,enable=${{ github.event_name == 'workflow_dispatch' }}
+            type=ref,event=branch
 
       - name: Login to GitHub Container Registry
         if: github.event_name != 'pull_request'

--- a/README.md
+++ b/README.md
@@ -5,11 +5,8 @@ Alpine based Docker image for running the [snapserver part of snapcast](https://
 
 Idea adapted from [librespot-snapserver](https://github.com/djmaze/librespot-snapserver) and based on [shairport-sync docker image](https://github.com/mikebrady/shairport-sync/tree/master/docker)
 
- **Background:** As of 01/2023 the last release of *snapcast* is v0.26 from 12/2021 which is missing 118 commits compared to `develop`.
- Same for *librespot*, last release is v0.46 from 07/2022 which is missing 266 commits compared to `dev`.
- Therefore, everything is compiled from source.
-
- **Note:** Current last commit of the respective development branches for all repos are used to compile the lastest versions.
+ **Background:** When this project started, the last releases of *snapcast* and *librespot* where outdated compared to their respective `develop` branches.
+  Therefore, everything is compiled from source using the development branches for all repos.
 
  **Note** The coresponding Docker image for runinng `snapclient` can be found here: [https://github.com/yubiuser/snapclient-docker](https://github.com/yubiuser/snapclient-docker)
 
@@ -44,13 +41,10 @@ To build the image simply run
 
 `docker build -t librespot-shairport-snapserver:local -f ./alpine.dockerfile .`
 
-
 ## Notes
 
-- Based on Alpine 3:18; final image size is ~116MB
+- Based on Alpine 3:19; final image size is ~116MB
 - All `(c)make` calles use the option `-j $(( $(nproc) -1 ))` to leave one CPU for normal operation
-- Compiling `snapserver`
-  - Logging of information of the `airplay-stream` metadata handler has been modified from `info` to `debug` to reduce logspam
 - `s6-overlay` is used as `init` system (same as the [shairport-sync docker image](https://github.com/mikebrady/shairport-sync/tree/master/docker)). This is necessary, because *shairport-sync* needs a companion application called [NQPTP](https://github.com/mikebrady/nqptp) which needs to be started from `root` to run as deamon.
   - `s6-rc` with configured dependencies is used to start all services. `snapserver` should start as last
   - `s6-notifyoncheck` is used to check readiness of the started services `dbus` and `avahi`. The actual check is performed by sending `dbus`messages and analyzing the reply.

--- a/alpine.dockerfile
+++ b/alpine.dockerfile
@@ -55,7 +55,7 @@ ENV CARGO_REGISTRIES_CRATES_IO_PROTOCOL="sparse"
 ENV CARGO_INCREMENTAL=0
 RUN git clone https://github.com/librespot-org/librespot \
    && cd librespot \
-   && git checkout 2ea7436e60750d56e747abfca3893be39c0162fd
+   && git checkout 22a8850fe98641c25f4b056dbcf36e332367d4cd
 WORKDIR /librespot
 RUN cargo build --release --no-default-features --features with-dns-sd -j $(( $(nproc) -1 ))
 

--- a/alpine.dockerfile
+++ b/alpine.dockerfile
@@ -70,8 +70,7 @@ FROM builder AS snapcast
 ### SNAPSERVER ###
 RUN git clone https://github.com/badaix/snapcast.git /snapcast \
     && cd snapcast \
-    && git checkout 86cd4b2b63e750a72e0dfe6a46d47caf01426c8d \
-    && sed -i 's/LOG(INFO, LOG_TAG) << "Waiting for metadata/LOG(DEBUG, LOG_TAG) << "Waiting for metadata/' "./server/streamreader/airplay_stream.cpp"
+    && git checkout b6c11930127d1ea6efe48de93b4add8ffe1fd0e9
 WORKDIR /snapcast
 RUN cmake -S . -B build -DBUILD_CLIENT=OFF \
     && cmake --build build -j $(( $(nproc) -1 )) --verbose \
@@ -86,8 +85,7 @@ RUN mkdir /snapserver-libs \
 ### SNAPWEB ###
 RUN git clone https://github.com/badaix/snapweb.git
 WORKDIR /snapweb
-# vite branch
-RUN git checkout c7812614e619b6490f53506ab4be7de8637f49a9
+RUN git checkout bdfa68a9e6457632604edb7cc7f5df0c4d23dd08
 ENV GENERATE_SOURCEMAP="false"
 RUN npm install -g npm@latest \
     && npm ci \

--- a/alpine.dockerfile
+++ b/alpine.dockerfile
@@ -55,7 +55,7 @@ ENV CARGO_REGISTRIES_CRATES_IO_PROTOCOL="sparse"
 ENV CARGO_INCREMENTAL=0
 RUN git clone https://github.com/librespot-org/librespot \
    && cd librespot \
-   && git checkout 299b7dec20b45b9fa19a4a46252079e8a8b7a8ba
+   && git checkout 2ea7436e60750d56e747abfca3893be39c0162fd
 WORKDIR /librespot
 RUN cargo build --release --no-default-features --features with-dns-sd -j $(( $(nproc) -1 ))
 
@@ -70,7 +70,7 @@ FROM builder AS snapcast
 ### SNAPSERVER ###
 RUN git clone https://github.com/badaix/snapcast.git /snapcast \
     && cd snapcast \
-    && git checkout 0a622d8441cf66c8c1d0eda9c4858687a0e87b5d
+    && git checkout 208066e5bb3f77482a62301283a8075912a7e22c
 WORKDIR /snapcast
 RUN cmake -S . -B build -DBUILD_CLIENT=OFF \
     && cmake --build build -j $(( $(nproc) -1 )) --verbose \
@@ -121,7 +121,7 @@ WORKDIR /
 ### SPS ###
 RUN git clone https://github.com/mikebrady/shairport-sync.git /shairport\
     && cd /shairport \
-    && git checkout 9650990523a719768fcedd234fa5c0dcff2185ec
+    && git checkout 92a933a376f7e5f838b4ed3f20e524a0b6f74f9d
 WORKDIR /shairport/build
 RUN autoreconf -i ../ \
     && ../configure --sysconfdir=/etc \

--- a/alpine.dockerfile
+++ b/alpine.dockerfile
@@ -55,7 +55,7 @@ ENV CARGO_INCREMENTAL=0
 
 RUN git clone https://github.com/librespot-org/librespot \
    && cd librespot \
-   && git checkout 22a8850fe98641c25f4b056dbcf36e332367d4cd
+   && git checkout 3781a089a69ce9883a299dfd191d90c9a5348819
 WORKDIR /librespot
 # aws-lc-rs requires bindgen for creating the crate
 # there are pre-build crates for x86_64-unknown-linux-musl but alpine images uses
@@ -126,7 +126,7 @@ WORKDIR /
 ### SPS ###
 RUN git clone https://github.com/mikebrady/shairport-sync.git /shairport\
     && cd /shairport \
-    && git checkout 92a933a376f7e5f838b4ed3f20e524a0b6f74f9d
+    && git checkout 654f59693240420ea96dba1354a06ce44d1293d7
 WORKDIR /shairport/build
 RUN autoreconf -i ../ \
     && ../configure --sysconfdir=/etc \

--- a/alpine.dockerfile
+++ b/alpine.dockerfile
@@ -191,7 +191,7 @@ COPY --from=base init /init
 COPY --from=base /tmp-libs/ /usr/lib/
 
 # Copy all necessary files from the builders
-COPY --from=librespot /librespot/target/release/librespot /usr/local/bin/
+COPY --from=librespot /librespot/target/x86_64-unknown-linux-musl/release/librespot /usr/local/bin/
 COPY --from=snapcast /snapcast/bin/snapserver /usr/local/bin/
 COPY --from=snapcast /snapweb/dist /usr/share/snapserver/snapweb
 COPY --from=shairport /shairport/build/shairport-sync /usr/local/bin/

--- a/alpine.dockerfile
+++ b/alpine.dockerfile
@@ -1,7 +1,7 @@
 ARG alpine_version=3.20
 ARG S6_OVERLAY_VERSION=3.2.0.0
 
-FROM docker.io/alpine:${alpine_version} as builder
+FROM docker.io/alpine:${alpine_version} AS builder
 RUN apk add --no-cache \
     # LIBRESPOT
     cargo \
@@ -55,7 +55,7 @@ ENV CARGO_REGISTRIES_CRATES_IO_PROTOCOL="sparse"
 ENV CARGO_INCREMENTAL=0
 RUN git clone https://github.com/librespot-org/librespot \
    && cd librespot \
-   && git checkout 8f9bec21d7a0d1e095039c1ff9ecd7c532d9e74e
+   && git checkout 299b7dec20b45b9fa19a4a46252079e8a8b7a8ba
 WORKDIR /librespot
 RUN cargo build --release --no-default-features --features with-dns-sd -j $(( $(nproc) -1 ))
 
@@ -70,7 +70,7 @@ FROM builder AS snapcast
 ### SNAPSERVER ###
 RUN git clone https://github.com/badaix/snapcast.git /snapcast \
     && cd snapcast \
-    && git checkout a31238a2fbf63c55c57dded9bfbe82e868f48cef
+    && git checkout 0a622d8441cf66c8c1d0eda9c4858687a0e87b5d
 WORKDIR /snapcast
 RUN cmake -S . -B build -DBUILD_CLIENT=OFF \
     && cmake --build build -j $(( $(nproc) -1 )) --verbose \
@@ -85,7 +85,7 @@ RUN mkdir /snapserver-libs \
 ### SNAPWEB ###
 RUN git clone https://github.com/badaix/snapweb.git
 WORKDIR /snapweb
-RUN git checkout 215da28e21e03e983b79f8232434c1ed1da9ef62
+RUN git checkout 66a15126578548ed544ab5b59acdece3825c2699
 ENV GENERATE_SOURCEMAP="false"
 RUN npm install -g npm@latest \
     && npm ci \
@@ -100,7 +100,7 @@ FROM builder AS shairport
 ### NQPTP ###
 RUN git clone https://github.com/mikebrady/nqptp
 WORKDIR /nqptp
-RUN git checkout b8384c4a53632bab028c451a625ef51a1e767f29 \
+RUN git checkout ee6663c99d95f9d25fbe07b0982a3c3b622ba0f5 \
     && autoreconf -i \
     && ./configure \
     && make -j $(( $(nproc) -1 ))
@@ -121,7 +121,7 @@ WORKDIR /
 ### SPS ###
 RUN git clone https://github.com/mikebrady/shairport-sync.git /shairport\
     && cd /shairport \
-    && git checkout 28ae1dae85ac58f78602f9ed0597247851d15473
+    && git checkout 9650990523a719768fcedd234fa5c0dcff2185ec
 WORKDIR /shairport/build
 RUN autoreconf -i ../ \
     && ../configure --sysconfdir=/etc \
@@ -143,7 +143,7 @@ RUN mkdir /shairport-libs \
 ###### SHAIRPORT BUNDLE END ######
 
 ###### BASE START ######
-FROM docker.io/alpine:${alpine_version} as base
+FROM docker.io/alpine:${alpine_version} AS base
 ARG S6_OVERLAY_VERSION
 RUN apk add --no-cache \
     avahi \

--- a/alpine.dockerfile
+++ b/alpine.dockerfile
@@ -55,7 +55,7 @@ ENV CARGO_REGISTRIES_CRATES_IO_PROTOCOL="sparse"
 ENV CARGO_INCREMENTAL=0
 RUN git clone https://github.com/librespot-org/librespot \
    && cd librespot \
-   && git checkout f5a46c61d2a1a96120516cee26cd7e4b95c20f50
+   && git checkout 4d35c5ffe222c839d1532d8afac78fe4c37043b3
 WORKDIR /librespot
 RUN cargo build --release --no-default-features --features with-dns-sd -j $(( $(nproc) -1 ))
 
@@ -70,7 +70,7 @@ FROM builder AS snapcast
 ### SNAPSERVER ###
 RUN git clone https://github.com/badaix/snapcast.git /snapcast \
     && cd snapcast \
-    && git checkout 0e74570dcc485b293fe09d9326529284f3b9e3a8 \
+    && git checkout 86cd4b2b63e750a72e0dfe6a46d47caf01426c8d \
     && sed -i 's/LOG(INFO, LOG_TAG) << "Waiting for metadata/LOG(DEBUG, LOG_TAG) << "Waiting for metadata/' "./server/streamreader/airplay_stream.cpp"
 WORKDIR /snapcast
 RUN cmake -S . -B build -DBUILD_CLIENT=OFF \
@@ -86,7 +86,8 @@ RUN mkdir /snapserver-libs \
 ### SNAPWEB ###
 RUN git clone https://github.com/badaix/snapweb.git
 WORKDIR /snapweb
-RUN git checkout ad2f6d4bed51ac3972193d1b4dde640c5428b1f7
+# vite branch
+RUN git checkout c7812614e619b6490f53506ab4be7de8637f49a9
 ENV GENERATE_SOURCEMAP="false"
 RUN npm install -g npm@latest \
     && npm ci \
@@ -101,7 +102,7 @@ FROM builder AS shairport
 ### NQPTP ###
 RUN git clone https://github.com/mikebrady/nqptp
 WORKDIR /nqptp
-RUN git checkout 5fb99599d87f09a38497c698173b46ac901ec7ce \
+RUN git checkout 6777e562b4c0cec54b8f419b85db48521258c605 \
     && autoreconf -i \
     && ./configure \
     && make -j $(( $(nproc) -1 ))
@@ -122,7 +123,7 @@ WORKDIR /
 ### SPS ###
 RUN git clone https://github.com/mikebrady/shairport-sync.git /shairport\
     && cd /shairport \
-    && git checkout 00a47584049789286e4ced0d95745066e4b0cb77
+    && git checkout 9862793256cf897330b4997fee66f488cbdb77cf
 WORKDIR /shairport/build
 RUN autoreconf -i ../ \
     && ../configure --sysconfdir=/etc \
@@ -187,7 +188,7 @@ COPY --from=base /tmp-libs/ /usr/lib/
 # Copy all necessary files from the builders
 COPY --from=librespot /librespot/target/release/librespot /usr/local/bin/
 COPY --from=snapcast /snapcast/bin/snapserver /usr/local/bin/
-COPY --from=snapcast /snapweb/build /usr/share/snapserver/snapweb
+COPY --from=snapcast /snapweb/dist /usr/share/snapserver/snapweb
 COPY --from=shairport /shairport/build/shairport-sync /usr/local/bin/
 COPY --from=shairport /nqptp/nqptp /usr/local/bin/
 

--- a/alpine.dockerfile
+++ b/alpine.dockerfile
@@ -55,7 +55,7 @@ ENV CARGO_REGISTRIES_CRATES_IO_PROTOCOL="sparse"
 ENV CARGO_INCREMENTAL=0
 RUN git clone https://github.com/librespot-org/librespot \
    && cd librespot \
-   && git checkout 4d35c5ffe222c839d1532d8afac78fe4c37043b3
+   && git checkout a6065d6bed3d40dabb9613fe773124e5b8380ecc
 WORKDIR /librespot
 RUN cargo build --release --no-default-features --features with-dns-sd -j $(( $(nproc) -1 ))
 
@@ -70,7 +70,7 @@ FROM builder AS snapcast
 ### SNAPSERVER ###
 RUN git clone https://github.com/badaix/snapcast.git /snapcast \
     && cd snapcast \
-    && git checkout b6c11930127d1ea6efe48de93b4add8ffe1fd0e9
+    && git checkout 245921009e015ed3cd1f635aed51b63cae7c1600
 WORKDIR /snapcast
 RUN cmake -S . -B build -DBUILD_CLIENT=OFF \
     && cmake --build build -j $(( $(nproc) -1 )) --verbose \
@@ -85,7 +85,7 @@ RUN mkdir /snapserver-libs \
 ### SNAPWEB ###
 RUN git clone https://github.com/badaix/snapweb.git
 WORKDIR /snapweb
-RUN git checkout bdfa68a9e6457632604edb7cc7f5df0c4d23dd08
+RUN git checkout eb23e03e9f7dc735f37b8e413fb803f1265938e2
 ENV GENERATE_SOURCEMAP="false"
 RUN npm install -g npm@latest \
     && npm ci \
@@ -100,7 +100,7 @@ FROM builder AS shairport
 ### NQPTP ###
 RUN git clone https://github.com/mikebrady/nqptp
 WORKDIR /nqptp
-RUN git checkout 6777e562b4c0cec54b8f419b85db48521258c605 \
+RUN git checkout 59ccf05444f88f7ceaa86c00f9bb64cc06c26cb4 \
     && autoreconf -i \
     && ./configure \
     && make -j $(( $(nproc) -1 ))
@@ -110,7 +110,7 @@ WORKDIR /
 ### ALAC ###
 RUN git clone https://github.com/mikebrady/alac
 WORKDIR /alac
-RUN git checkout 96dd59d17b776a7dc94ed9b2c2b4a37177feb3c4 \
+RUN git checkout 34b327964c2287a49eb79b88b0ace278835ae95f \
     && autoreconf -i \
     && ./configure \
     && make -j $(( $(nproc) -1 )) \
@@ -121,7 +121,7 @@ WORKDIR /
 ### SPS ###
 RUN git clone https://github.com/mikebrady/shairport-sync.git /shairport\
     && cd /shairport \
-    && git checkout 9862793256cf897330b4997fee66f488cbdb77cf
+    && git checkout 5d24d847683aad97eeb4efe6448ac726feb50143
 WORKDIR /shairport/build
 RUN autoreconf -i ../ \
     && ../configure --sysconfdir=/etc \

--- a/alpine.dockerfile
+++ b/alpine.dockerfile
@@ -46,7 +46,7 @@ RUN apk add --no-cache \
     xxd
 
 ###### LIBRESPOT START ######
-FROM docker.io/alpine:${alpine_version} AS librespot
+FROM builder AS librespot
 # Strip debug symbols
 ENV RUSTFLAGS="-C strip=symbols"
 # Use the new "sparse" protocol which speeds up the cargo index update massively
@@ -64,7 +64,7 @@ ENV RUSTUP_HOME=/usr/local/rustup \
     PATH=/usr/local/cargo/bin:$PATH
 RUN curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y --no-modify-path --profile minimal
 ENV RUSTFLAGS="-C target-feature=-crt-static"
-RUN cargo build --no-default-features --features with-dns-sd -j $(( $(nproc) -1 )) --target x86_64-unknown-linux-musl
+RUN cargo build --release --no-default-features --features with-dns-sd -j $(( $(nproc) -1 )) --target x86_64-unknown-linux-musl
 
 # Gather all shared libaries necessary to run the executable
 RUN mkdir /librespot-libs \

--- a/debian.dockerfile
+++ b/debian.dockerfile
@@ -64,7 +64,7 @@ ENV CARGO_INCREMENTAL=0
 ENV RUSTFLAGS="-C link-args=-fuse-ld=mold -C strip=symbols"
 RUN git clone https://github.com/librespot-org/librespot \
    && cd librespot \
-   && git checkout f5a46c61d2a1a96120516cee26cd7e4b95c20f50
+   && git checkout 4d35c5ffe222c839d1532d8afac78fe4c37043b3
 WORKDIR /librespot
 RUN cargo build --release --no-default-features --features with-dns-sd -j $(( $(nproc) -1 ))
 
@@ -79,7 +79,7 @@ FROM builder AS snapcast
 ### SNAPSERVER ###
 RUN git clone https://github.com/badaix/snapcast.git /snapcast \
     && cd snapcast \
-    && git checkout 0e74570dcc485b293fe09d9326529284f3b9e3a8 \
+    && git checkout 86cd4b2b63e750a72e0dfe6a46d47caf01426c8d \
     && sed -i 's/LOG(INFO, LOG_TAG) << "Waiting for metadata/LOG(DEBUG, LOG_TAG) << "Waiting for metadata/' "./server/streamreader/airplay_stream.cpp"
 WORKDIR /snapcast
 RUN cmake -S . -B build -DBUILD_CLIENT=OFF \
@@ -95,7 +95,8 @@ RUN mkdir /snapserver-libs \
 ### SNAPWEB ###
 RUN git clone https://github.com/badaix/snapweb.git
 WORKDIR /snapweb
-RUN git checkout ad2f6d4bed51ac3972193d1b4dde640c5428b1f7
+# vite branch
+RUN git checkout c7812614e619b6490f53506ab4be7de8637f49a9
 ENV GENERATE_SOURCEMAP="false"
 RUN npm install -g npm@latest \
     && npm ci \
@@ -110,7 +111,7 @@ FROM builder AS shairport
 ### NQPTP ###
 RUN git clone https://github.com/mikebrady/nqptp
 WORKDIR /nqptp
-RUN git checkout 5fb99599d87f09a38497c698173b46ac901ec7ce \
+RUN git checkout 6777e562b4c0cec54b8f419b85db48521258c605 \
     && autoreconf -i \
     && ./configure \
     && make -j $(( $(nproc) -1 ))
@@ -132,7 +133,7 @@ RUN cp /usr/local/lib/libalac.* /usr/lib/
 ### SPS ###
 RUN git clone https://github.com/mikebrady/shairport-sync.git /shairport\
     && cd /shairport \
-    && git checkout 00a47584049789286e4ced0d95745066e4b0cb77
+    && git checkout 9862793256cf897330b4997fee66f488cbdb77cf
 WORKDIR /shairport/build
 RUN autoreconf -i ../ \
     && ../configure --sysconfdir=/etc \
@@ -204,7 +205,7 @@ COPY --from=base /tmp-libs/ /lib/x86_64-linux-gnu/
 # Copy all necessary files from the builders
 COPY --from=librespot /librespot/target/release/librespot /usr/local/bin/
 COPY --from=snapcast /snapcast/bin/snapserver /usr/local/bin/
-COPY --from=snapcast /snapweb/build /usr/share/snapserver/snapweb
+COPY --from=snapcast /snapweb/dist /usr/share/snapserver/snapweb
 COPY --from=shairport /shairport/build/shairport-sync /usr/local/bin/
 COPY --from=shairport /nqptp/nqptp /usr/local/bin/
 

--- a/debian.dockerfile
+++ b/debian.dockerfile
@@ -79,8 +79,7 @@ FROM builder AS snapcast
 ### SNAPSERVER ###
 RUN git clone https://github.com/badaix/snapcast.git /snapcast \
     && cd snapcast \
-    && git checkout 86cd4b2b63e750a72e0dfe6a46d47caf01426c8d \
-    && sed -i 's/LOG(INFO, LOG_TAG) << "Waiting for metadata/LOG(DEBUG, LOG_TAG) << "Waiting for metadata/' "./server/streamreader/airplay_stream.cpp"
+    && git checkout 86cd4b2b63e750a72e0dfe6a46d47caf01426c8d
 WORKDIR /snapcast
 RUN cmake -S . -B build -DBUILD_CLIENT=OFF \
     && cmake --build build -j $(( $(nproc) -1 )) --verbose \
@@ -95,8 +94,7 @@ RUN mkdir /snapserver-libs \
 ### SNAPWEB ###
 RUN git clone https://github.com/badaix/snapweb.git
 WORKDIR /snapweb
-# vite branch
-RUN git checkout c7812614e619b6490f53506ab4be7de8637f49a9
+RUN git checkout bdfa68a9e6457632604edb7cc7f5df0c4d23dd08
 ENV GENERATE_SOURCEMAP="false"
 RUN npm install -g npm@latest \
     && npm ci \

--- a/debian.dockerfile
+++ b/debian.dockerfile
@@ -64,7 +64,7 @@ ENV CARGO_INCREMENTAL=0
 ENV RUSTFLAGS="-C link-args=-fuse-ld=mold -C strip=symbols"
 RUN git clone https://github.com/librespot-org/librespot \
    && cd librespot \
-   && git checkout 4d35c5ffe222c839d1532d8afac78fe4c37043b3
+   && git checkout a6065d6bed3d40dabb9613fe773124e5b8380ecc
 WORKDIR /librespot
 RUN cargo build --release --no-default-features --features with-dns-sd -j $(( $(nproc) -1 ))
 
@@ -79,7 +79,7 @@ FROM builder AS snapcast
 ### SNAPSERVER ###
 RUN git clone https://github.com/badaix/snapcast.git /snapcast \
     && cd snapcast \
-    && git checkout 86cd4b2b63e750a72e0dfe6a46d47caf01426c8d
+    && git checkout 245921009e015ed3cd1f635aed51b63cae7c1600
 WORKDIR /snapcast
 RUN cmake -S . -B build -DBUILD_CLIENT=OFF \
     && cmake --build build -j $(( $(nproc) -1 )) --verbose \
@@ -94,7 +94,7 @@ RUN mkdir /snapserver-libs \
 ### SNAPWEB ###
 RUN git clone https://github.com/badaix/snapweb.git
 WORKDIR /snapweb
-RUN git checkout bdfa68a9e6457632604edb7cc7f5df0c4d23dd08
+RUN git checkout eb23e03e9f7dc735f37b8e413fb803f1265938e2
 ENV GENERATE_SOURCEMAP="false"
 RUN npm install -g npm@latest \
     && npm ci \
@@ -109,7 +109,7 @@ FROM builder AS shairport
 ### NQPTP ###
 RUN git clone https://github.com/mikebrady/nqptp
 WORKDIR /nqptp
-RUN git checkout 6777e562b4c0cec54b8f419b85db48521258c605 \
+RUN git checkout 59ccf05444f88f7ceaa86c00f9bb64cc06c26cb4 \
     && autoreconf -i \
     && ./configure \
     && make -j $(( $(nproc) -1 ))
@@ -119,7 +119,7 @@ WORKDIR /
 ### ALAC ###
 RUN git clone https://github.com/mikebrady/alac
 WORKDIR /alac
-RUN git checkout 96dd59d17b776a7dc94ed9b2c2b4a37177feb3c4 \
+RUN git checkout 34b327964c2287a49eb79b88b0ace278835ae95f \
     && autoreconf -i \
     && ./configure \
     && make -j $(( $(nproc) -1 )) \
@@ -131,7 +131,7 @@ RUN cp /usr/local/lib/libalac.* /usr/lib/
 ### SPS ###
 RUN git clone https://github.com/mikebrady/shairport-sync.git /shairport\
     && cd /shairport \
-    && git checkout 9862793256cf897330b4997fee66f488cbdb77cf
+    && git checkout 5d24d847683aad97eeb4efe6448ac726feb50143
 WORKDIR /shairport/build
 RUN autoreconf -i ../ \
     && ../configure --sysconfdir=/etc \


### PR DESCRIPTION
Updates
 
- `librespot` to `3781a089a69ce9883a299dfd191d90c9a5348819`
- `shairport-sync` to `654f59693240420ea96dba1354a06ce44d1293d7`
- `nqptp` to `ee6663c99d95f9d25fbe07b0982a3c3b622ba0f5`
- `snapcast` to `208066e5bb3f77482a62301283a8075912a7e22c`
- `snapweb` to `66a15126578548ed544ab5b59acdece3825c2699`

- Fixes the `librespot` step since it has `aws-lc-sys` as indirect dependency
- Adjust CI workflow to build and tag on PRs - prepare for multi-arch build (currently not enabled due to extremely slow build time >6h)

plus some workflow dependencies