### PR TITLE
Re-add avahi zeroconf backend

### DIFF
--- a/alpine.dockerfile
+++ b/alpine.dockerfile
@@ -40,7 +40,7 @@ ENV CARGO_INCREMENTAL=0
 RUN cargo +nightly build \
     -Z build-std=std,panic_abort \
     -Z build-std-features="optimize_for_size,panic_immediate_abort" \
-    --release --no-default-features -j $(( $(nproc) -1 ))\
+    --release --no-default-features --features with-avahi -j $(( $(nproc) -1 ))\
     --target x86_64-unknown-linux-musl
 
 ###### LIBRESPOT END ######


### PR DESCRIPTION
I removed the zeroconf backend with https://github.com/yubiuser/librespot-shairport-snapserver/pull/83, but it turned out this was not a wise step. Spotify deprecated the user/password login and so did `librespot`.  This leaves 3 options:

https://github.com/librespot-org/librespot/wiki/Options#authentication

But using `OAuth` on a headless system is not a nice experience and the access token has only a limited lifetime. Thankfully, https://github.com/librespot-org/librespot/pull/1347 added a new zeroconf backend that directly uses `avahi` via `dbus` (both are present in the container) and which can be statically compiled.