### PR TITLE
Disable static build of lib alsa as it is currentyl broken on musl

### DIFF
--- a/alpine.dockerfile
+++ b/alpine.dockerfile
@@ -123,7 +123,7 @@ RUN apk add --no-cache \
     cmake \
     git
 
-RUN git clone https://gitlab.xiph.org/xiph/opus.git /opus
+RUN git clone https://github.com/xiph/opus.git /opus
 WORKDIR /opus
 RUN mkdir build \
     && cd build \


### PR DESCRIPTION
Disable ALSA static build as of https://github.com/alsa-project/alsa-lib/pull/459 static build on musl is broken